### PR TITLE
fixed minor run script errors

### DIFF
--- a/SwiftAA.xcodeproj/project.pbxproj
+++ b/SwiftAA.xcodeproj/project.pbxproj
@@ -2211,7 +2211,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cp -Rf ${BUILT_PRODUCTS_DIR}/SwiftAA.framework ${SRCROOT}/SwiftAA/SwiftAA.playground/Resources/";
+			shellScript = "cp -Rf \"${BUILT_PRODUCTS_DIR}/SwiftAA.framework/\" \"${SRCROOT}/SwiftAA/SwiftAA.playground/Resources/\"";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
1. Run script fails on archive if ${BUILD_PRODUCTS_DIR} contains spaces (added quotes)
2. Run script fails on archive if ${BUILD_PRODUCTS_DIR}/SwiftAA.framework is a symlink (added additional slash)