### PR TITLE
fixed an error introduced in fe83bea

### DIFF
--- a/SwiftAA.xcodeproj/project.pbxproj
+++ b/SwiftAA.xcodeproj/project.pbxproj
@@ -2211,7 +2211,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cp -Rf \"${BUILT_PRODUCTS_DIR}/SwiftAA.framework/\" \"${SRCROOT}/SwiftAA/SwiftAA.playground/Resources/\"";
+			shellScript = "cp -Rf \"${BUILT_PRODUCTS_DIR}/SwiftAA.framework/\" \"${SRCROOT}/SwiftAA/SwiftAA.playground/Resources/SwiftAA.framework/\"";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
In fe83bea I fixed `cp` error complaining it can't copy symlink into directory, but copy destination was wrong. My bad.