### PR TITLE
Improved tests

### DIFF
--- a/SwiftAA.xcodeproj/project.pbxproj
+++ b/SwiftAA.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		6F5C3ED71E073BB200F572F6 /* Distances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FB755271E05B59D00EC7617 /* Distances.swift */; };
 		6F5C3ED81E073BC600F572F6 /* RiseTransitSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F877AFE1E052B83006FC6E5 /* RiseTransitSet.swift */; };
 		6F5C3ED91E073BE100F572F6 /* JupiterMoons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FE80D781DCF488600CC6623 /* JupiterMoons.swift */; };
+		6FBCF9381E12210C00786EB4 /* XCTestExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FBCF9361E12210200786EB4 /* XCTestExtensions.swift */; };
 		9F058A141D9108FE00D5E710 /* EllipticalPlanetaryDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F058A131D9108FE00D5E710 /* EllipticalPlanetaryDetails.swift */; };
 		9F058A151D9108FE00D5E710 /* EllipticalPlanetaryDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F058A131D9108FE00D5E710 /* EllipticalPlanetaryDetails.swift */; };
 		9F1F129A1D7C6A83006FD828 /* Magnitudes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F1F12991D7C6A83006FD828 /* Magnitudes.swift */; };
@@ -714,6 +715,7 @@
 		6F21411C1E0E4CD5005E1913 /* SunTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SunTests.swift; sourceTree = "<group>"; };
 		6F21411E1E0E5076005E1913 /* MoonTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MoonTests.swift; sourceTree = "<group>"; };
 		6F2141201E0F13D0005E1913 /* RiseTransitSetTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RiseTransitSetTests.swift; sourceTree = "<group>"; };
+		6FBCF9361E12210200786EB4 /* XCTestExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCTestExtensions.swift; sourceTree = "<group>"; };
 		9F058A131D9108FE00D5E710 /* EllipticalPlanetaryDetails.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EllipticalPlanetaryDetails.swift; sourceTree = "<group>"; };
 		9F1F12991D7C6A83006FD828 /* Magnitudes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Magnitudes.swift; sourceTree = "<group>"; };
 		9F2154A51D296B4000C4DD06 /* Planets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Planets.swift; sourceTree = "<group>"; };
@@ -1714,6 +1716,7 @@
 				6F2141201E0F13D0005E1913 /* RiseTransitSetTests.swift */,
 				6F21411C1E0E4CD5005E1913 /* SunTests.swift */,
 				9F7A56FE1D15F2F40033CDC5 /* VenusTests.swift */,
+				6FBCF9361E12210200786EB4 /* XCTestExtensions.swift */,
 			);
 			name = Swift;
 			sourceTree = "<group>";
@@ -2685,6 +2688,7 @@
 				9FAA86511D8D85C800DF095E /* JulianDayTests.swift in Sources */,
 				6F21411F1E0E5076005E1913 /* MoonTests.swift in Sources */,
 				6F21411B1E0E1AA5005E1913 /* AstronomicalCoordinatesTests.swift in Sources */,
+				6FBCF9381E12210C00786EB4 /* XCTestExtensions.swift in Sources */,
 				9FC340301D156A5D0069E7C4 /* KPCAA2DCoordinateTests.swift in Sources */,
 				9FFA28FD1D156CC600034972 /* KPCAA3DCoordinateTests.swift in Sources */,
 				6F21411D1E0E4CD5005E1913 /* SunTests.swift in Sources */,

--- a/SwiftAA/Angles.swift
+++ b/SwiftAA/Angles.swift
@@ -46,6 +46,9 @@ public struct ArcMinute: NumericType {
     
     public var inDegrees: Degree { return Degree(value / 60.0) }
     public var inArcseconds: ArcSecond { return ArcSecond(value * 60.0) }
+    public var inHours: Hour { return inDegrees.inHours }
+    public var inRadians: Double { return inDegrees.inRadians }
+    
 }
 
 // MARK: -
@@ -58,6 +61,8 @@ public struct ArcSecond: NumericType {
     
     public var inDegrees: Degree { return Degree(value / 3600.0) }
     public var inArcminutes: ArcMinute { return ArcMinute(value / 60.0) }
+    public var inHours: Hour { return inDegrees.inHours }
+    public var inRadians: Double { return inDegrees.inRadians }
 
     public func distance() -> AU {
         return AU(KPCAAParallax_ParallaxToDistance(inDegrees.value))

--- a/SwiftAA/Angles.swift
+++ b/SwiftAA/Angles.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct Degree: NumericType {
+public struct Degree: NumericType, CustomStringConvertible {
     public let value: Double
     public init(_ value: Double) {
         self.value = value
@@ -25,9 +25,6 @@ public struct Degree: NumericType {
     
     /// Returns self reduced to 0..<360 range 
     public var reduced: Degree { return Degree(value.positiveTruncatingRemainder(dividingBy: 360.0)) }
-}
-
-extension Degree: CustomStringConvertible {
     public var description: String {
         let deg = value.rounded(.towardZero)
         let min = ((value - deg) * 60.0).rounded(.towardZero)
@@ -38,7 +35,7 @@ extension Degree: CustomStringConvertible {
 
 // MARK: -
 
-public struct ArcMinute: NumericType {
+public struct ArcMinute: NumericType, CustomStringConvertible {
     public let value: Double
     public init(_ value: Double) {
         self.value = value
@@ -49,11 +46,12 @@ public struct ArcMinute: NumericType {
     public var inHours: Hour { return inDegrees.inHours }
     public var inRadians: Double { return inDegrees.inRadians }
     
+    public var description: String { return String(format: "%.2f arcmin", value) }
 }
 
 // MARK: -
 
-public struct ArcSecond: NumericType {
+public struct ArcSecond: NumericType, CustomStringConvertible {
     public let value: Double
     public init(_ value: Double) {
         self.value = value
@@ -67,6 +65,7 @@ public struct ArcSecond: NumericType {
     public func distance() -> AU {
         return AU(KPCAAParallax_ParallaxToDistance(inDegrees.value))
     }
+    public var description: String { return String(format: "%.2f arcsec", value) }
 }
 
 

--- a/SwiftAA/Angles.swift
+++ b/SwiftAA/Angles.swift
@@ -13,6 +13,10 @@ public struct Degree: NumericType {
     public init(_ value: Double) {
         self.value = value
     }
+    public init(_ degrees: Double, _ arcminutes: Double, _ arcseconds: Double) {
+        guard degrees.sign == arcminutes.sign && degrees.sign == arcseconds.sign else { fatalError("degrees/arcminutes/arcseconds must have the same sign") }
+        self.init(degrees + arcminutes/60.0 + arcseconds/3600.0)
+    }
     
     public var inArcminutes: ArcMinute { return ArcMinute(value * 60.0) }
     public var inArcseconds: ArcSecond { return ArcSecond(value * 3600.0) }

--- a/SwiftAA/AstronomicalCoordinates.swift
+++ b/SwiftAA/AstronomicalCoordinates.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct EquatorialCoordinates {
+public struct EquatorialCoordinates: CustomStringConvertible {
     fileprivate(set) var rightAscension: Hour
     fileprivate(set) var declination: Degree
     public let epoch: JulianDay
@@ -83,9 +83,12 @@ public struct EquatorialCoordinates {
                                                            otherCoordinates.alpha.value,
                                                            otherCoordinates.delta.value))
     }
+    
+    public var description: String { return String(format: "α=%@, δ=%@", alpha.description, delta.description) }
+    
 }
 
-public struct EclipticCoordinates {
+public struct EclipticCoordinates: CustomStringConvertible {
     fileprivate(set) var celestialLongitude: Degree
     fileprivate(set) var celestialLatitude: Degree
     public let epoch: JulianDay
@@ -126,9 +129,12 @@ public struct EclipticCoordinates {
         let components = KPCAAPrecession_PrecessEcliptic(self.celestialLongitude.value, self.celestialLatitude.value, self.epoch.value, newEpoch.value)
         return EclipticCoordinates(lambda: Degree(components.X), beta: Degree(components.Y), epsilon: newEpoch)
     }
+    
+    public var description: String { return String(format: "λ=%@, β=%@", lambda.description, beta.description) }
+    
 }
 
-public struct GalacticCoordinates {
+public struct GalacticCoordinates: CustomStringConvertible {
     fileprivate(set) var galacticLongitude: Degree
     fileprivate(set) var galacticLatitude: Degree
     public let epoch: JulianDay = StandardEpoch_B1950_0
@@ -158,9 +164,12 @@ public struct GalacticCoordinates {
         let components = KPCAACoordinateTransformation_Galactic2Equatorial(self.galacticLongitude.value, self.galacticLatitude.value)
         return EquatorialCoordinates(alpha: Hour(components.X), delta: Degree(components.Y), epsilon: self.epoch)
     }
+    
+    public var description: String { return String(format: "l=%@, b=%@", l.description, b.description) }
+    
 }
 
-public struct HorizontalCoordinates {
+public struct HorizontalCoordinates: CustomStringConvertible {
     fileprivate(set) var azimuth: Degree // westward from the South see AA. p91
     fileprivate(set) var altitude: Degree
     fileprivate(set) var geographicCoordinates: GeographicCoordinates
@@ -182,6 +191,8 @@ public struct HorizontalCoordinates {
         let lst = julianDay.meanLocalSiderealTime(forGeographicLongitude: geographicCoordinates.longitude.value)
         return EquatorialCoordinates(alpha: Hour(lst.value - components.X).reduced, delta: Degree(components.Y), epsilon: self.epoch)
     }
-
+    
+    public var description: String { return String(format: "A=%@, h=%@", azimuth.description, altitude.description) }
+    
 }
 

--- a/SwiftAA/Distances.swift
+++ b/SwiftAA/Distances.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 
-public struct AU: NumericType {
+public struct AU: NumericType, CustomStringConvertible {
     public let value: Double
     public init(_ value: Double) {
         self.value = value
@@ -24,17 +24,19 @@ public struct AU: NumericType {
         return Degree(KPCAAParallax_DistanceToParallax(value)).inArcseconds
     }
 
+    public var description: String { return String(format: "%.2f au", value) }
 }
 
 // MARK: -
 
-public struct Meter: NumericType {
+public struct Meter: NumericType, CustomStringConvertible {
     public let value: Double
     public init(_ value: Double) {
         self.value = value
     }
     
     public var AstronomicalUnit: AU { return AU(value / 149597870700.0) }
+    public var description: String { return String(format: "%.0f meters", value) }
 }
 
 

--- a/SwiftAA/Times.swift
+++ b/SwiftAA/Times.swift
@@ -21,6 +21,7 @@ public struct Hour: NumericType {
     public var inMinutes: Minute { return Minute(value * 60.0) }
     public var inSeconds: Second { return Second(value * 3600.0) }
     public var inDegrees: Degree { return Degree(value * 15.0) }
+    public var inDays: JulianDay { return JulianDay(value / 24.0) }
     
     /// Returns self reduced to 0..<24 range
     public var reduced: Hour { return Hour(value.positiveTruncatingRemainder(dividingBy: 24.0)) }
@@ -47,6 +48,7 @@ public struct Minute: NumericType {
     public var inHours: Hour { return Hour(value / 60.0) }
     public var inSeconds: Second { return Second(value * 60.0) }
     public var inDegrees: Degree { return Degree(value / 60.0 * 15.0) }
+    public var inDays: JulianDay { return JulianDay(value / 1440.0) }
     
     /// Returns self reduced to 0..<60 range
     public var reduced: Minute { return Minute(value.positiveTruncatingRemainder(dividingBy: 60.0)) }
@@ -64,6 +66,7 @@ public struct Second: NumericType {
     public var inHours: Hour { return Hour(value / 3600.0) }
     public var inMinutes: Minute { return Minute(value / 60.0) }
     public var inDegrees: Degree { return Degree(value / 3600.0 * 15.0) }
+    public var inDays: JulianDay { return JulianDay(value / 86400.0) }
     
     /// Returns self reduced to 0..<60 range
     public var reduced: Second { return Second(value.positiveTruncatingRemainder(dividingBy: 60.0)) }

--- a/SwiftAA/Times.swift
+++ b/SwiftAA/Times.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct Hour: NumericType {
+public struct Hour: NumericType, CustomStringConvertible {
     public let value: Double
     public init(_ value: Double) {
         self.value = value
@@ -26,9 +26,6 @@ public struct Hour: NumericType {
     /// Returns self reduced to 0..<24 range
     public var reduced: Hour { return Hour(value.positiveTruncatingRemainder(dividingBy: 24.0)) }
     
-}
-
-extension Hour: CustomStringConvertible {
     public var description: String {
         let hrs = value.rounded(.towardZero)
         let min = ((value - hrs) * 60.0).rounded(.towardZero)
@@ -39,7 +36,7 @@ extension Hour: CustomStringConvertible {
 
 // MARK: -
 
-public struct Minute: NumericType {
+public struct Minute: NumericType, CustomStringConvertible {
     public let value: Double
     public init(_ value: Double) {
         self.value = value
@@ -53,11 +50,12 @@ public struct Minute: NumericType {
     /// Returns self reduced to 0..<60 range
     public var reduced: Minute { return Minute(value.positiveTruncatingRemainder(dividingBy: 60.0)) }
     
+    public var description: String { return String(format: "%.2f min", value) }
 }
 
 // MARK: -
 
-public struct Second: NumericType {
+public struct Second: NumericType, CustomStringConvertible {
     public let value: Double
     public init(_ value: Double) {
         self.value = value
@@ -71,5 +69,6 @@ public struct Second: NumericType {
     /// Returns self reduced to 0..<60 range
     public var reduced: Second { return Second(value.positiveTruncatingRemainder(dividingBy: 60.0)) }
     
+    public var description: String { return String(format: "%.2f sec", value) }
 }
 

--- a/SwiftAA/Times.swift
+++ b/SwiftAA/Times.swift
@@ -13,6 +13,10 @@ public struct Hour: NumericType {
     public init(_ value: Double) {
         self.value = value
     }
+    public init(_ hours: Double, _ minutes: Double, _ seconds: Double) {
+        guard hours.sign == minutes.sign && hours.sign == seconds.sign else { fatalError("hours/minutes/seconds must have the same sign") }
+        self.init(hours + minutes/60.0 + seconds/3600.0)
+    }
     
     public var inMinutes: Minute { return Minute(value * 60.0) }
     public var inSeconds: Second { return Second(value * 3600.0) }

--- a/SwiftAATests/AstronomicalCoordinatesTests.swift
+++ b/SwiftAATests/AstronomicalCoordinatesTests.swift
@@ -12,35 +12,35 @@ import XCTest
 class AstronomicalCoordinatesTests: XCTestCase {
     
     func testEquatorial2Ecliptic() { // p.95
-        let equatorial = EquatorialCoordinates(alpha: Hour(7.0 + 45.0/60.0 + 18.946/3600.0), delta: Degree(28.0 + 1.0/60.0 + 34.26/3600.0))
+        let equatorial = EquatorialCoordinates(alpha: Hour(7, 45, 18.946), delta: Degree(28, 1, 34.26))
         let ecliptic = equatorial.toEclipticCoordinates()
-        XCTAssertEqualWithAccuracy(ecliptic.lambda.value, 113.215630, accuracy: 0.01/3600.0)
-        XCTAssertEqualWithAccuracy(ecliptic.beta.value, 6.684170, accuracy: 0.01/3600.0)
+        AssertEqual(ecliptic.lambda, Degree(113.215630), accuracy: ArcSecond(0.01).inDegrees)
+        AssertEqual(ecliptic.beta, Degree(6.684170), accuracy: ArcSecond(0.01).inDegrees)
         let eqBack = ecliptic.toEquatorialCoordinates()
-        XCTAssertEqualWithAccuracy(eqBack.rightAscension.value, equatorial.rightAscension.value, accuracy: 0.1/3600.0)
-        XCTAssertEqualWithAccuracy(eqBack.declination.value, equatorial.declination.value, accuracy: 0.1/3600.0)
+        AssertEqual(eqBack.rightAscension, equatorial.rightAscension, accuracy: ArcSecond(0.01).inHours)
+        AssertEqual(eqBack.declination, equatorial.declination, accuracy: ArcSecond(0.01).inDegrees)
     }
     
     func testEquatorial2Horizontal() { // p.95
-        let date = Calendar.gregorianGMT.date(from: DateComponents(year: 1987, month: 04, day: 10, hour: 19, minute: 21, second: 00))!
-        let equatorial = EquatorialCoordinates(alpha: Hour(23.0 + 9.0/60.0 + 16.641/3600.0), delta: Degree( -6.0 - 43.0/60.0 - 11.61/3600.0))
-        let geographic = GeographicCoordinates(positivelyWestwardLongitude: Degree(77.0 + 3.0/60.0 + 56.0/3600.0), latitude: Degree(38.0 + 55.0/60.0 + 17.0/3600.0))
-        let horizontal = equatorial.toHorizontalCoordinates(forGeographicalCoordinates: geographic, julianDay: date.julianDay)
-        XCTAssertEqualWithAccuracy(horizontal.altitude.value, 15.1249, accuracy: 0.001)
-        XCTAssertEqualWithAccuracy(horizontal.azimuth.value, 68.0337, accuracy: 0.001)
+        let jd = JulianDay(year: 1987, month: 4, day: 10, hour: 19, minute: 21, second: 0)
+        let equatorial = EquatorialCoordinates(alpha: Hour(23, 9, 16.641), delta: Degree(-6, -43, -11.61))
+        let geographic = GeographicCoordinates(positivelyWestwardLongitude: Degree(77, 3, 56.0), latitude: Degree(38, 55, 17.0))
+        let horizontal = equatorial.toHorizontalCoordinates(forGeographicalCoordinates: geographic, julianDay: jd)
+        AssertEqual(horizontal.altitude, Degree(15.1249), accuracy: ArcSecond(5.0).inDegrees)
+        AssertEqual(horizontal.azimuth, Degree(68.0337), accuracy: ArcSecond(5.0).inDegrees)
         let eqBack = horizontal.toEquatorialCoordinates()
-        XCTAssertEqualWithAccuracy(eqBack.rightAscension.value, equatorial.rightAscension.value, accuracy: 0.1/3600.0)
-        XCTAssertEqualWithAccuracy(eqBack.declination.value, equatorial.declination.value, accuracy: 0.1/3600.0)
+        AssertEqual(eqBack.rightAscension, equatorial.rightAscension, accuracy: ArcSecond(0.01).inHours)
+        AssertEqual(eqBack.declination, equatorial.declination, accuracy: ArcSecond(0.01).inDegrees)
     }
     
     func testEquatorial2Galactic() { // p.95
-        let equatorial = EquatorialCoordinates(alpha: Hour(17.0 + 48.0/60.0 + 59.74/3600.0), delta: Degree( -14.0 - 43.0/60.0 - 8.2/3600.0), epsilon: StandardEpoch_B1950_0)
+        let equatorial = EquatorialCoordinates(alpha: Hour(17, 48, 59.74), delta: Degree(-14, -43, -8.2), epsilon: StandardEpoch_B1950_0)
         let galactic = equatorial.toGalacticCoordinates()
-        XCTAssertEqualWithAccuracy(galactic.l.value, 12.9593, accuracy: 0.001)
-        XCTAssertEqualWithAccuracy(galactic.b.value, 6.0463, accuracy: 0.001)
+        AssertEqual(galactic.l, Degree(12.9593), accuracy: ArcSecond(1.0).inDegrees)
+        AssertEqual(galactic.b, Degree(6.0463), accuracy: ArcSecond(1.0).inDegrees)
         let eqBack = galactic.toEquatorialCoordinates()
-        XCTAssertEqualWithAccuracy(eqBack.rightAscension.value, equatorial.rightAscension.value, accuracy: 0.1/3600.0)
-        XCTAssertEqualWithAccuracy(eqBack.declination.value, equatorial.declination.value, accuracy: 0.1/3600.0)
+        AssertEqual(eqBack.rightAscension, equatorial.rightAscension, accuracy: ArcSecond(0.01).inHours)
+        AssertEqual(eqBack.declination, equatorial.declination, accuracy: ArcSecond(0.01).inDegrees)
     }
     
 }

--- a/SwiftAATests/ConstantsTests.swift
+++ b/SwiftAATests/ConstantsTests.swift
@@ -10,25 +10,16 @@ import XCTest
 @testable import SwiftAA
 
 class ConstantsTests: XCTestCase {
-
-    override func setUp() {
-        super.setUp()
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-    }
     
-    override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-        super.tearDown()
-    }
-
     /// That's the Geocentric to Topocentric parallax correction. See AA p280.
     func testParallaxToDistance() {
         let parallax1: ArcSecond = 23.592
-        XCTAssertEqualWithAccuracy(parallax1.distance().value, 0.37276, accuracy: 0.0005)
+        AssertEqual(parallax1.distance(), AU(0.37276), accuracy: AU(0.0005))
     }
     
     func testDistanceToParallax() {
         let distance1: AU = 0.37276
-        XCTAssertEqualWithAccuracy(distance1.parallax().value, 23.592, accuracy: 0.0005)
+        AssertEqual(distance1.parallax(), ArcSecond(23.592), accuracy: ArcSecond(0.0005))
     }
+    
 }

--- a/SwiftAATests/JulianDayTests.swift
+++ b/SwiftAATests/JulianDayTests.swift
@@ -10,17 +10,7 @@ import XCTest
 @testable import SwiftAA
 
 class JulianDayTest: XCTestCase {
-
-    override func setUp() {
-        super.setUp()
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-    }
     
-    override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-        super.tearDown()
-    }
-
     func testDate1ToJulianDay() {
         var components = DateComponents()
         components.year = 2016
@@ -40,8 +30,8 @@ class JulianDayTest: XCTestCase {
         components.second = 4
         components.nanosecond = 500000000
         let date = Calendar.gregorianGMT.date(from: components)!
-        let jd = 2421123.5 + 2.0/24.0 + 3.0/1440.0 + (4.0+500000000/1e9)/86400.0
-        XCTAssertEqualWithAccuracy(date.julianDay.value, jd, accuracy: 0.001/86400.0)
+        let jd = JulianDay(2421123.5 + 2.0/24.0 + 3.0/1440.0 + (4.0+500000000/1e9)/86400.0)
+        AssertEqual(date.julianDay, jd, accuracy: Second(0.001).inDays)
     }
 
     func testJulianDayToDateComponents() {
@@ -61,7 +51,7 @@ class JulianDayTest: XCTestCase {
         let jd = JulianDay(2457743.5 + 01.0/24.0 + 04.0/1440.0 + 09.1035/86400)
         testJulian(components, jd)
         let jd2 = JulianDay(year: 2016, month: 12, day: 21, hour: 1, minute: 4, second: 9.1035)
-        XCTAssertEqualWithAccuracy(jd.value, jd2.value, accuracy: 0.0001/86400)
+        AssertEqual(jd, jd2, accuracy: Second(0.001).inDays)
     }
     
     func testJulian1980() {
@@ -85,27 +75,27 @@ class JulianDayTest: XCTestCase {
         let accuracy = TimeInterval(0.001)
         XCTAssertEqualWithAccuracy(date.timeIntervalSinceReferenceDate, date1.timeIntervalSinceReferenceDate, accuracy: accuracy)
         XCTAssertEqualWithAccuracy(date.timeIntervalSinceReferenceDate, date2.timeIntervalSinceReferenceDate, accuracy: accuracy)
-        XCTAssertEqualWithAccuracy(jd.value, jd1.value, accuracy: accuracy / 86400.0)
-        XCTAssertEqualWithAccuracy(jd.value, jd2.value, accuracy: accuracy / 86400.0)
+        AssertEqual(jd, jd1, accuracy: Second(accuracy).inDays)
+        AssertEqual(jd, jd2, accuracy: Second(accuracy).inDays)
     }
     
-    func testMeanSiderealTime1() {
-        let date = Calendar.gregorianGMT.date(from: DateComponents(year: 1987, month: 04, day: 10, hour: 00, minute: 00, second: 00))!
-        let gmst = date.julianDay.meanGreenwichSiderealTime()
-        XCTAssertEqualWithAccuracy(gmst.value, 13.0 + 10.0/60.0 + 46.3668/3600.0, accuracy: 0.001 / 3600.0) // p.88
+    func testMeanSiderealTime1() { // See AA p.88
+        let jd = JulianDay(year: 1987, month: 04, day: 10)
+        let gmst = jd.meanGreenwichSiderealTime()
+        AssertEqual(gmst, Hour(13, 10, 46.3668), accuracy: Second(0.001).inHours)
     }
     
-    func testMeanSiderealTime2() {
-        let date = Calendar.gregorianGMT.date(from: DateComponents(year: 1987, month: 04, day: 10, hour: 19, minute: 21, second: 00))!
-        let gmst = date.julianDay.meanGreenwichSiderealTime()
-        XCTAssertEqualWithAccuracy(gmst.value, 8.0 + 34.0/60.0 + 57.0898/3600.0, accuracy: 0.001 / 3600.0) // p.89
+    func testMeanSiderealTime2() { // See AA p.89
+        let jd = JulianDay(year: 1987, month: 04, day: 10, hour: 19, minute: 21, second: 00)
+        let gmst = jd.meanGreenwichSiderealTime()
+        AssertEqual(gmst, Hour(8, 34, 57.0898), accuracy: Second(0.001).inHours)
     }
     
-    func testMeanLocalSiderealTime1() {
-        let date = Calendar.gregorianGMT.date(from: DateComponents(year: 2016, month: 12, day: 01, hour: 14, minute: 15, second: 03))!
+    func testMeanLocalSiderealTime1() { // Data from SkySafari
+        let jd = JulianDay(year: 2016, month: 12, day: 1, hour: 14, minute: 15, second: 3)
         let geographic = GeographicCoordinates(positivelyWestwardLongitude: -37.615559, latitude: 55.752220)
-        let lmst = date.julianDay.meanLocalSiderealTime(forGeographicLongitude: geographic.longitude.value)
-        XCTAssertEqualWithAccuracy(lmst.value, 21.0 + 28.0/60.0 + 59.0/3600.0, accuracy: 1.0/3600.0) // SkySafari
+        let lmst = jd.meanLocalSiderealTime(forGeographicLongitude: geographic.longitude.value)
+        AssertEqual(lmst, Hour(21, 28, 59.0), accuracy: Second(1.0).inHours)
     }
     
 }

--- a/SwiftAATests/MoonTests.swift
+++ b/SwiftAATests/MoonTests.swift
@@ -11,13 +11,12 @@ import XCTest
 
 class MoonTests: XCTestCase {
     
-    func testPosition() { // p.343
-        let date = Calendar.gregorianGMT.date(from: DateComponents(year: 1992, month: 04, day: 12, hour: 00, minute: 00, second: 00))!
-        let moon = Moon(julianDay: date.julianDay)
+    func testEquatorialCoordinates() { // p.343
+        let moon = Moon(julianDay: JulianDay(year: 1992, month: 04, day: 12, hour: 00, minute: 00, second: 00))
         let equatorial = moon.equatorialCoordinates
         // FIXME: the reason for bad accuracy we use *mean* position instead of *apparent* in the book
-        XCTAssertEqualWithAccuracy(equatorial.rightAscension.value, 134.688470/15.0, accuracy: 0.1/3600.0)
-        XCTAssertEqualWithAccuracy(equatorial.declination.value, 13.768368, accuracy: 10.0/3600.0)
+        AssertEqual(equatorial.rightAscension, Degree(134.688470).inHours, accuracy: ArcMinute(0.1).inHours)
+        AssertEqual(equatorial.declination, Degree(13.768368), accuracy: ArcMinute(0.1).inDegrees)
     }
     
 }

--- a/SwiftAATests/NutationTests.swift
+++ b/SwiftAATests/NutationTests.swift
@@ -11,12 +11,12 @@ import XCTest
 
 class NutationTests: XCTestCase {
     
-    func testObliquity() { // p.148
-        let date = Calendar.gregorianGMT.date(from: DateComponents(year: 1987, month: 04, day: 10, hour: 00, minute: 00, second: 00))!
-        let meanObliquity = obliquityOfEcliptic(julianDay: date.julianDay, mean: true)
-        XCTAssertEqualWithAccuracy(meanObliquity.value, 23.0 + 26.0/60.0 + 27.407/3600.0, accuracy: 0.01/3600.0)
-        let trueObliquity = obliquityOfEcliptic(julianDay: date.julianDay, mean: false)
-        XCTAssertEqualWithAccuracy(trueObliquity.value, 23.0 + 26.0/60.0 + 36.850/3600.0, accuracy: 0.01/3600.0)
+    func testObliquity() { // See AA p.148
+        let jd = JulianDay(year: 1987, month: 4, day: 10, hour: 0, minute: 0, second: 0)
+        let meanObliquity = obliquityOfEcliptic(julianDay: jd, mean: true)
+        AssertEqual(meanObliquity, Degree(23, 26, 27.407), accuracy: ArcSecond(0.01).inDegrees)
+        let trueObliquity = obliquityOfEcliptic(julianDay: jd, mean: false)
+        AssertEqual(trueObliquity, Degree(23, 26, 36.850), accuracy: ArcSecond(0.01).inDegrees)
     }
     
 }

--- a/SwiftAATests/PlanetaryBaseTest.swift
+++ b/SwiftAATests/PlanetaryBaseTest.swift
@@ -12,16 +12,6 @@ import XCTest
 class PlanetaryBaseTest: XCTestCase {
     var jd: JulianDay = 0.0
     
-    override func setUp() {
-        super.setUp()
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-    }
-    
-    override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-        super.tearDown()
-    }
-
     func testMercuryTypes() {
         let mercury = Mercury(julianDay: self.jd)
         XCTAssertEqual(mercury.name, "Mercury")

--- a/SwiftAATests/RiseTransitSetTests.swift
+++ b/SwiftAATests/RiseTransitSetTests.swift
@@ -11,17 +11,17 @@ import XCTest
 
 class RiseTransitSetTests: XCTestCase {
     
-    func testVenusAtBoston1988() { // AA p.103
+    func testVenusAtBoston1988() { // See AA p.103
         let boston = GeographicCoordinates(positivelyWestwardLongitude: 71.0833, latitude: 42.3333)
-        let date = Calendar.gregorianGMT.date(from: DateComponents(year: 1988, month: 03, day: 20))!
-        let venus = Venus(julianDay: date.julianDay)
+        let venus = Venus(julianDay: JulianDay(year: 1988, month: 3, day: 20))
         let details = RiseTransitSetTimes(celestialBody: venus, geographicCoordinates: boston)
-        let expectedRise = Calendar.gregorianGMT.date(from: DateComponents(year: 1988, month: 03, day: 20, hour: 12, minute: 25))!
-        let expectedTransit = Calendar.gregorianGMT.date(from: DateComponents(year: 1988, month: 03, day: 20, hour: 19, minute: 41))!
-        let expectedSet = Calendar.gregorianGMT.date(from: DateComponents(year: 1988, month: 03, day: 20, hour: 2, minute: 55))!
-        XCTAssertEqualWithAccuracy(details.riseTime!.value, expectedRise.julianDay.value, accuracy: 1.0/1440.0)
-        XCTAssertEqualWithAccuracy(details.transitTime!.value, expectedTransit.julianDay.value, accuracy: 1.0/1440.0)
-        XCTAssertEqualWithAccuracy(details.setTime!.value, expectedSet.julianDay.value, accuracy: 1.0/1440.0)
+        let accuracy = Minute(1.0).inDays
+        let expectedRise = JulianDay(year: 1988, month: 03, day: 20, hour: 12, minute: 25)
+        AssertEqual(details.riseTime!, expectedRise, accuracy: accuracy)
+        let expectedTransit = JulianDay(year: 1988, month: 03, day: 20, hour: 19, minute: 41)
+        AssertEqual(details.transitTime!, expectedTransit, accuracy: accuracy)
+        let expectedSet = JulianDay(year: 1988, month: 03, day: 20, hour: 2, minute: 55)
+        AssertEqual(details.setTime!, expectedSet, accuracy: accuracy)
     }
     
 }

--- a/SwiftAATests/SunTests.swift
+++ b/SwiftAATests/SunTests.swift
@@ -11,13 +11,12 @@ import XCTest
 
 class SunTests: XCTestCase {
     
-    func testPosition() { // p.165
-        let date = Calendar.gregorianGMT.date(from: DateComponents(year: 1993, month: 10, day: 13, hour: 00, minute: 00, second: 00))!
-        let sun = Sun(julianDay: date.julianDay)
+    func testPosition() { // See AA p.165
+        let sun = Sun(julianDay: JulianDay(year: 1993, month: 10, day: 13))
         let equatorial = sun.equatorialCoordinates
         // FIXME: the reason for very bad accuracy we use *mean* position instead of *apparent* in the book
-        XCTAssertEqualWithAccuracy(equatorial.rightAscension.value, 13.225389, accuracy: 1.0/60.0)
-        XCTAssertEqualWithAccuracy(equatorial.declination.value, -7.78507, accuracy: 0.1)
+        AssertEqual(equatorial.rightAscension, Hour(13.225389), accuracy: Degree(0.5).inHours)
+        AssertEqual(equatorial.declination, Degree(-7.78507), accuracy: Degree(0.1))
     }
     
 }

--- a/SwiftAATests/VenusTests.swift
+++ b/SwiftAATests/VenusTests.swift
@@ -12,48 +12,30 @@ import XCTest
 
 class VenusTests: XCTestCase {
 
-    // See AA p.225
-    func testApparentGeocentricCoordinates() {
-        // Months going from 1 to 12
-        var components = DateComponents()
-        components.year = 1992
-        components.month = 12
-        components.day = 20
-        let date = Calendar.gregorianGMT.date(from: components)!
-        let venus = Venus(julianDay: date.julianDay)
-        
-        XCTAssertEqualWithAccuracy(venus.planetaryDetails.ApparentGeocentricRA, 21.078181, accuracy: 0.000001)
-        XCTAssertEqualWithAccuracy(venus.planetaryDetails.ApparentGeocentricDeclination, -18.88801, accuracy: 0.000001)
+    func testApparentGeocentricCoordinates() { // See AA p.225
+        let venus = Venus(julianDay: JulianDay(year: 1992, month: 12, day: 20))
+        AssertEqual(Hour(venus.planetaryDetails.ApparentGeocentricRA), Hour(21.078181), accuracy: ArcSecond(0.1).inHours)
+        AssertEqual(Degree(venus.planetaryDetails.ApparentGeocentricDeclination), Degree(-18.88801), accuracy: ArcSecond(0.1).inDegrees)
     }
     
-    
-    // See AA p.284
-    func testIlluminationFraction() {
-        // Months going from 1 to 12
-        var components = DateComponents()
-        components.year = 1992
-        components.month = 12
-        components.day = 20
-        let date = Calendar.gregorianGMT.date(from: components)!
-        // Both radius vector are correct. Not Delta! Check.
-        let frac = Venus(julianDay: date.julianDay).illuminatedFraction
-        XCTAssertEqualWithAccuracy(frac, 0.647, accuracy: 0.005)
+    func testIlluminationFraction() { // See AA p.284
+        let venus = Venus(julianDay: JulianDay(year: 1992, month: 12, day: 20))
+        XCTAssertEqualWithAccuracy(venus.illuminatedFraction, 0.647, accuracy: 0.005)
     }
     
-    func testHeliocentricEclipticCoordinates() { // AA p.225
-        let date = Calendar.gregorianGMT.date(from: DateComponents(year: 1992, month: 12, day: 20))!.julianDay
-        let venus = Venus(julianDay: date, highPrecision: false)
+    func testHeliocentricEclipticCoordinates() { // See AA p.225
+        let venus = Venus(julianDay: JulianDay(year: 1992, month: 12, day: 20), highPrecision: false)
         let heliocentricEcliptic = venus.eclipticCoordinates
-        XCTAssertEqualWithAccuracy(heliocentricEcliptic.celestialLatitude.value, -2.62070, accuracy: 0.00001)
-        XCTAssertEqualWithAccuracy(heliocentricEcliptic.celestialLongitude.value, 26.11428, accuracy: 0.00001)
-        XCTAssertEqualWithAccuracy(venus.radiusVector.value, 0.724603, accuracy: 0.00001)
+        AssertEqual(heliocentricEcliptic.celestialLatitude, Degree(-2.62070), accuracy: ArcSecond(0.1).inDegrees)
+        AssertEqual(heliocentricEcliptic.celestialLongitude, Degree(26.11428), accuracy: ArcSecond(0.1).inDegrees)
+        AssertEqual(venus.radiusVector, AU(0.724603), accuracy: AU(0.00001))
     }
     
-    func testEquatorialCoordinates() { // p.103
-        let jd = JulianDay(year: 1988, month: 03, day: 20, hour: 00, minute: 00, second: 00)
-        let equatorial = Venus(julianDay: jd).apparentEquatorialCoordinates
-        XCTAssertEqualWithAccuracy(equatorial.rightAscension.inDegrees.value, 41.73129, accuracy: 0.1/60.0)
-        XCTAssertEqualWithAccuracy(equatorial.declination.value, 18.44092, accuracy: 0.1/60.0)
+    func testGeocentricEquatorialCoordinates() { // See AA p.103
+        let venus = Venus(julianDay: JulianDay(year: 1988, month: 03, day: 20))
+        let equatorial = venus.apparentEquatorialCoordinates
+        AssertEqual(equatorial.rightAscension.inDegrees, Degree(41.73129), accuracy: ArcSecond(0.1).inDegrees)
+        AssertEqual(equatorial.declination, Degree(18.44092), accuracy: ArcSecond(0.1).inDegrees)
     }
-
+    
 }

--- a/SwiftAATests/XCTestExtensions.swift
+++ b/SwiftAATests/XCTestExtensions.swift
@@ -1,0 +1,21 @@
+//
+//  XCTestExtensions.swift
+//  SwiftAA
+//
+//  Created by Alexander Vasenin on 27/12/2016.
+//  Copyright © 2016 onekiloparsec. All rights reserved.
+//
+
+import XCTest
+@testable import SwiftAA
+
+/// This function is a type-safe way to test NumericType's equality
+func AssertEqual<T : NumericType>(_ value1: T, _ value2: T, accuracy: T? = nil, _ message: String = "", file: StaticString = #file, line: UInt = #line) {
+    if let _accuracy = accuracy {
+        XCTAssertEqualWithAccuracy(value1.value, value2.value, accuracy: _accuracy.value, message, file: file, line: line)
+    } else {
+        XCTAssertEqual(value1.value, value2.value, message, file: file, line: line)
+    }
+}
+
+


### PR DESCRIPTION
Type-safe testing for all types conforming to NumericType

    XCTAssertEqualWithAccuracy(equatorial.rightAscension.value, 134.688470/15.0, accuracy: 0.1/3600.0) // before
    AssertEqual(equatorial.rightAscension, Degree(134.688470).inHours, accuracy: ArcMinute(0.1).inHours) // after

Also several convenience initializers

    XCTAssertEqualWithAccuracy(trueObliquity.value, 23.0 + 26.0/60.0 + 36.850/3600.0, accuracy: 0.01/3600.0) // before
    AssertEqual(trueObliquity, Degree(23, 26, 36.850), accuracy: ArcSecond(0.01).inDegrees) // after
