### PR TITLE
fixed Moon.timeOfPhase()

### DIFF
--- a/SwiftAA/Moon.swift
+++ b/SwiftAA/Moon.swift
@@ -109,7 +109,7 @@ public class Moon : Object, CelestialBody {
     
     // MARK: - KPCAAMoonPhases
 
-    func timeOfPhase(forPhase ph: MoonPhase, mean: Bool = true) -> JulianDay {
+    public func timeOfPhase(forPhase ph: MoonPhase, isNext: Bool = true, mean: Bool = true) -> JulianDay {
         var k = round(KPCAAMoonPhases_K(self.julianDay.date.fractionalYear))
         switch ph {
         case .new:
@@ -121,7 +121,20 @@ public class Moon : Object, CelestialBody {
         case .lastQuarter: 
             k = k + 0.75
         }
-        return mean ? JulianDay(KPCAAMoonPhases_MeanPhase(k)) : JulianDay(KPCAAMoonPhases_TruePhase(k))
+        let preliminary = timeOfPhase(k, isMean: mean)
+        let isActuallyNext = preliminary > julianDay
+        switch (isNext, isActuallyNext) {
+        case (true, true), (false, false):
+            return preliminary
+        case (true, false):
+            return timeOfPhase(k+1.0, isMean: mean)
+        case (false, true):
+            return timeOfPhase(k-1.0, isMean: mean)
+        }
+    }
+    
+    fileprivate func timeOfPhase(_ k: Double, isMean: Bool) -> JulianDay {
+        return isMean ? JulianDay(KPCAAMoonPhases_MeanPhase(k)) : JulianDay(KPCAAMoonPhases_TruePhase(k))
     }
 
     // MARK: - KPCAAMoonPhysicalDetails

--- a/SwiftAATests/MoonTests.swift
+++ b/SwiftAATests/MoonTests.swift
@@ -19,6 +19,19 @@ class MoonTests: XCTestCase {
         AssertEqual(equatorial.declination, Degree(13.768368), accuracy: ArcMinute(0.1).inDegrees)
     }
     
+    func testTimeOfPhase() { // AA p.353
+        let date1 = Moon(julianDay: JulianDay(year: 1977, month: 1, day: 20)).timeOfPhase(forPhase: .new, isNext: true, mean: false)
+        let date2 = Moon(julianDay: JulianDay(year: 1977, month: 2, day: 17)).timeOfPhase(forPhase: .new, isNext: true, mean: false)
+        let date3 = Moon(julianDay: JulianDay(year: 1977, month: 2, day: 19)).timeOfPhase(forPhase: .new, isNext: false, mean: false)
+        let date4 = Moon(julianDay: JulianDay(year: 1977, month: 3, day: 19)).timeOfPhase(forPhase: .new, isNext: false, mean: false)
+        let expected = JulianDay(year: 1977, month: 2, day: 18, hour: 3, minute: 37, second: 42)
+        let accuracy = JulianDay(1.0/86400.0)
+        AssertEqual(date1, expected, accuracy: accuracy)
+        AssertEqual(date2, expected, accuracy: accuracy)
+        AssertEqual(date3, expected, accuracy: accuracy)
+        AssertEqual(date4, expected, accuracy: accuracy)
+    }
+    
 }
 
 


### PR DESCRIPTION
1. fixed bug: Moon.timeOfPhase() should be public
2. fixed bug: Moon.timeOfPhase() returns next or previous phase unpredictably
3. Added tests for Moon.timeOfPhase()

note: just ceiling/flooring `k` doesn't work, we have to calculate it second time in some cases