### PR TITLE
Update localmidnight

### DIFF
--- a/SwiftAA/JulianDay.swift
+++ b/SwiftAA/JulianDay.swift
@@ -107,7 +107,7 @@ public extension JulianDay {
      - returns: A Julian Day struct, corresponding to the geometric midnight local to a given Earth longitude.
      */
     public func localMidnight(longitude: Degree) -> JulianDay {
-        return self.midnight + longitude.inHours.inJulianDays
+        return (self - longitude.inHours.inJulianDays).midnight + longitude.inHours.inJulianDays
     }
     
     /**

--- a/SwiftAA/JulianDay.swift
+++ b/SwiftAA/JulianDay.swift
@@ -109,7 +109,12 @@ public extension JulianDay {
     public func localMidnight(longitude: Degree) -> JulianDay {
         return (self - longitude.inHours.inJulianDays).midnight + longitude.inHours.inJulianDays
     }
-    
+
+    public func localMidnight(timeZone: TimeZone) -> JulianDay {
+        let offsetFromGMT = JulianDay(Double(timeZone.secondsFromGMT(for: self.date)) / (60*60*24))
+        return (self + offsetFromGMT).midnight - offsetFromGMT
+    }
+
     /**
      Computes the mean sidereal time for the Greenwich meridian.
      That is, the Greenwich hour angle of the mean vernal point (the intersection of the ecliptic

--- a/SwiftAATests/JulianDayTests.swift
+++ b/SwiftAATests/JulianDayTests.swift
@@ -125,19 +125,19 @@ class JulianDayTest: XCTestCase {
         let jd = JulianDay(year: 2016, month: 12, day: 20, hour: 3, minute: 5, second: 3.5)
         
         let longitude1 = 0.0.degrees
-        AssertEqual(jd.localMidnight(longitude: longitude1), jd.midnight)
+        AssertEqual(jd.localMidnight(longitude: longitude1), JulianDay(year: 2016, month: 12, day: 20, hour: 0))
         
         let longitude2 = 15.0.degrees
-        AssertEqual(jd.localMidnight(longitude: longitude2), jd.midnight + 1.0.hours.inJulianDays)
-        
+        AssertEqual(jd.localMidnight(longitude: longitude2), JulianDay(year: 2016, month: 12, day: 20, hour: 1))
+
         let longitude3 = -15.0.degrees
-        AssertEqual(jd.localMidnight(longitude: longitude3), jd.midnight - 1.0.hours.inJulianDays)
-        
+        AssertEqual(jd.localMidnight(longitude: longitude3), JulianDay(year: 2016, month: 12, day: 19, hour: 23))
+
         let longitude4 = 90.0.degrees
-        AssertEqual(jd.localMidnight(longitude: longitude4), jd.midnight + 6.0.hours.inJulianDays)
-        
+        AssertEqual(jd.localMidnight(longitude: longitude4), JulianDay(year: 2016, month: 12, day: 19, hour: 6))
+
         let longitude5 = -90.0.degrees
-        AssertEqual(jd.localMidnight(longitude: longitude5), jd.midnight - 6.0.hours.inJulianDays)
+        AssertEqual(jd.localMidnight(longitude: longitude5), JulianDay(year: 2016, month: 12, day: 19, hour: 18))
     }
     
     // See AA p.78

--- a/SwiftAATests/JulianDayTests.swift
+++ b/SwiftAATests/JulianDayTests.swift
@@ -121,7 +121,7 @@ class JulianDayTest: XCTestCase {
         AssertEqual(jd2.midnight, JulianDay(year: 2016, month: 12, day: 19))
     }
     
-    func testLocalMidnight() {
+    func testLocalMidnightForLongitude() {
         let jd = JulianDay(year: 2016, month: 12, day: 20, hour: 3, minute: 5, second: 3.5)
         
         let longitude1 = 0.0.degrees
@@ -138,6 +138,25 @@ class JulianDayTest: XCTestCase {
 
         let longitude5 = -90.0.degrees
         AssertEqual(jd.localMidnight(longitude: longitude5), JulianDay(year: 2016, month: 12, day: 19, hour: 18))
+    }
+
+    func testLocalMidnightForTimeZone() {
+        let jd = JulianDay(year: 2016, month: 12, day: 20, hour: 3, minute: 5, second: 3.5)
+
+        let timeZone0 = TimeZone(secondsFromGMT: 0)!
+        AssertEqual(jd.localMidnight(timeZone: timeZone0), JulianDay(year: 2016, month: 12, day: 20, hour: 0))
+
+        let timeZone1 = TimeZone(secondsFromGMT: -1 * 60 * 60)!
+        AssertEqual(jd.localMidnight(timeZone: timeZone1), JulianDay(year: 2016, month: 12, day: 20, hour: 1))
+
+        let timeZone2 = TimeZone(secondsFromGMT: +1 * 60 * 60)!
+        AssertEqual(jd.localMidnight(timeZone: timeZone2), JulianDay(year: 2016, month: 12, day: 19, hour: 23))
+
+        let timeZone3 = TimeZone(secondsFromGMT: -6 * 60 * 60)!
+        AssertEqual(jd.localMidnight(timeZone: timeZone3), JulianDay(year: 2016, month: 12, day: 19, hour: 6))
+
+        let timeZone4 = TimeZone(secondsFromGMT: +6 * 60 * 60)!
+        AssertEqual(jd.localMidnight(timeZone: timeZone4), JulianDay(year: 2016, month: 12, day: 19, hour: 18))
     }
     
     // See AA p.78


### PR DESCRIPTION
Close #54 

Also introduces `localMidnight(timeZone:)` which will be necessary for correct calculation of sunrise/sunset/moonrise/moonset for non-GMT timezones.