### PR TITLE
made fatalError() drop-in replacement internal (instead of public)

### DIFF
--- a/SwiftAA/Constants.swift
+++ b/SwiftAA/Constants.swift
@@ -27,8 +27,8 @@ import Foundation
 // See https://stackoverflow.com/questions/32873212/unit-test-fatalerror-in-swift?answertab=active#tab-top
 // to make possible to unit test fatalError.
 //
-// overrides Swift global `fatalError`
-public func fatalError(_ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) -> Never {
+// testable drop-in replacement for `fatalError()`
+internal func fatalError(_ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) -> Never {
     FatalErrorUtil.fatalErrorClosure(message(), file, line)
 //    unreachable()
 }


### PR DESCRIPTION
It's a very bad idea to introduce *public* function with the exact same name as standard Swift function. Declaring such function *does not* override system function `Swift.fatalError()`, but merely creates a new function `SwiftAA.fatalError()` with the same signature. Since local scope take precedence, calling unqualified `fatalError()` from SwiftAA module will call local function. However, if you call unqualified `fatalError()` from other module which has SwiftAA imported, swift compiler would not be able to infer which function to call, `Swift.fatalError()` or `SwiftAA.fatalError()` and you'll get `Ambiguous use of 'fatalError(_:file:line:)'` error on every fatalError call.