### PR TITLE
Fix Xcode 10.2 compilation errors and warnings

### DIFF
--- a/ObjCAA/KPCAAElementsPlanetaryOrbit.mm
+++ b/ObjCAA/KPCAAElementsPlanetaryOrbit.mm
@@ -124,35 +124,35 @@ double KPCAAElementsPlanetaryOrbit_NeptuneLongitudePerihelionJ2000(double JD) { 
 double KPCAAElementsPlanetaryOrbit_MeanLongitude(KPCAAPlanetStrict planet, double JD)
 {
     switch (planet) {
-        case Mercury: {
+        case mercury: {
             return KPCAAElementsPlanetaryOrbit_MercuryMeanLongitude(JD);
             break;
         }
-        case Venus: {
+        case venus: {
             return KPCAAElementsPlanetaryOrbit_VenusMeanLongitude(JD);
             break;
         }
-        case Earth: {
+        case earth: {
             return KPCAAElementsPlanetaryOrbit_EarthMeanLongitude(JD);
             break;
         }
-        case Mars: {
+        case mars: {
             return KPCAAElementsPlanetaryOrbit_MarsMeanLongitude(JD);
             break;
         }
-        case Jupiter: {
+        case jupiter: {
             return KPCAAElementsPlanetaryOrbit_JupiterMeanLongitude(JD);
             break;
         }
-        case Saturn: {
+        case saturn: {
             return KPCAAElementsPlanetaryOrbit_SaturnMeanLongitude(JD);
             break;
         }
-        case Uranus: {
+        case uranus: {
             return KPCAAElementsPlanetaryOrbit_UranusMeanLongitude(JD);
             break;
         }
-        case Neptune: {
+        case neptune: {
             return KPCAAElementsPlanetaryOrbit_NeptuneMeanLongitude(JD);
             break;
         }
@@ -166,35 +166,35 @@ double KPCAAElementsPlanetaryOrbit_MeanLongitude(KPCAAPlanetStrict planet, doubl
 double KPCAAElementsPlanetaryOrbit_MeanLongitudeJ2000(KPCAAPlanetStrict planet, double JD)
 {
     switch (planet) {
-        case Mercury: {
+        case mercury: {
             return KPCAAElementsPlanetaryOrbit_MercuryMeanLongitudeJ2000(JD);
             break;
         }
-        case Venus: {
+        case venus: {
             return KPCAAElementsPlanetaryOrbit_VenusMeanLongitudeJ2000(JD);
             break;
         }
-        case Earth: {
+        case earth: {
             return KPCAAElementsPlanetaryOrbit_EarthMeanLongitudeJ2000(JD);
             break;
         }
-        case Mars: {
+        case mars: {
             return KPCAAElementsPlanetaryOrbit_MarsMeanLongitudeJ2000(JD);
             break;
         }
-        case Jupiter: {
+        case jupiter: {
             return KPCAAElementsPlanetaryOrbit_JupiterMeanLongitudeJ2000(JD);
             break;
         }
-        case Saturn: {
+        case saturn: {
             return KPCAAElementsPlanetaryOrbit_SaturnMeanLongitudeJ2000(JD);
             break;
         }
-        case Uranus: {
+        case uranus: {
             return KPCAAElementsPlanetaryOrbit_UranusMeanLongitudeJ2000(JD);
             break;
         }
-        case Neptune: {
+        case neptune: {
             return KPCAAElementsPlanetaryOrbit_NeptuneMeanLongitudeJ2000(JD);
             break;
         }
@@ -208,35 +208,35 @@ double KPCAAElementsPlanetaryOrbit_MeanLongitudeJ2000(KPCAAPlanetStrict planet, 
 double KPCAAElementsPlanetaryOrbit_SemimajorAxis(KPCAAPlanetStrict planet, double JD)
 {
     switch (planet) {
-        case Mercury: {
+        case mercury: {
             return KPCAAElementsPlanetaryOrbit_MercurySemimajorAxis(JD);
             break;
         }
-        case Venus: {
+        case venus: {
             return KPCAAElementsPlanetaryOrbit_VenusSemimajorAxis(JD);
             break;
         }
-        case Earth: {
+        case earth: {
             return KPCAAElementsPlanetaryOrbit_EarthSemimajorAxis(JD);
             break;
         }
-        case Mars: {
+        case mars: {
             return KPCAAElementsPlanetaryOrbit_MarsSemimajorAxis(JD);
             break;
         }
-        case Jupiter: {
+        case jupiter: {
             return KPCAAElementsPlanetaryOrbit_JupiterSemimajorAxis(JD);
             break;
         }
-        case Saturn: {
+        case saturn: {
             return KPCAAElementsPlanetaryOrbit_SaturnSemimajorAxis(JD);
             break;
         }
-        case Uranus: {
+        case uranus: {
             return KPCAAElementsPlanetaryOrbit_UranusSemimajorAxis(JD);
             break;
         }
-        case Neptune: {
+        case neptune: {
             return KPCAAElementsPlanetaryOrbit_NeptuneSemimajorAxis(JD);
             break;
         }
@@ -251,35 +251,35 @@ double KPCAAElementsPlanetaryOrbit_SemimajorAxis(KPCAAPlanetStrict planet, doubl
 double KPCAAElementsPlanetaryOrbit_Eccentricity(KPCAAPlanetStrict planet, double JD)
 {
     switch (planet) {
-        case Mercury: {
+        case mercury: {
             return KPCAAElementsPlanetaryOrbit_MercuryEccentricity(JD);
             break;
         }
-        case Venus: {
+        case venus: {
             return KPCAAElementsPlanetaryOrbit_VenusEccentricity(JD);
             break;
         }
-        case Earth: {
+        case earth: {
             return KPCAAElementsPlanetaryOrbit_EarthEccentricity(JD);
             break;
         }
-        case Mars: {
+        case mars: {
             return KPCAAElementsPlanetaryOrbit_MarsEccentricity(JD);
             break;
         }
-        case Jupiter: {
+        case jupiter: {
             return KPCAAElementsPlanetaryOrbit_JupiterEccentricity(JD);
             break;
         }
-        case Saturn: {
+        case saturn: {
             return KPCAAElementsPlanetaryOrbit_SaturnEccentricity(JD);
             break;
         }
-        case Uranus: {
+        case uranus: {
             return KPCAAElementsPlanetaryOrbit_UranusEccentricity(JD);
             break;
         }
-        case Neptune: {
+        case neptune: {
             return KPCAAElementsPlanetaryOrbit_NeptuneEccentricity(JD);
             break;
         }
@@ -293,35 +293,35 @@ double KPCAAElementsPlanetaryOrbit_Eccentricity(KPCAAPlanetStrict planet, double
 double KPCAAElementsPlanetaryOrbit_Inclination(KPCAAPlanetStrict planet, double JD)
 {
     switch (planet) {
-        case Mercury: {
+        case mercury: {
             return KPCAAElementsPlanetaryOrbit_MercuryInclination(JD);
             break;
         }
-        case Venus: {
+        case venus: {
             return KPCAAElementsPlanetaryOrbit_VenusInclination(JD);
             break;
         }
-        case Earth: {
+        case earth: {
             return KPCAAElementsPlanetaryOrbit_EarthInclination(JD);
             break;
         }
-        case Mars: {
+        case mars: {
             return KPCAAElementsPlanetaryOrbit_MarsInclination(JD);
             break;
         }
-        case Jupiter: {
+        case jupiter: {
             return KPCAAElementsPlanetaryOrbit_JupiterInclination(JD);
             break;
         }
-        case Saturn: {
+        case saturn: {
             return KPCAAElementsPlanetaryOrbit_SaturnInclination(JD);
             break;
         }
-        case Uranus: {
+        case uranus: {
             return KPCAAElementsPlanetaryOrbit_UranusInclination(JD);
             break;
         }
-        case Neptune: {
+        case neptune: {
             return KPCAAElementsPlanetaryOrbit_NeptuneInclination(JD);
             break;
         }
@@ -335,35 +335,35 @@ double KPCAAElementsPlanetaryOrbit_Inclination(KPCAAPlanetStrict planet, double 
 double KPCAAElementsPlanetaryOrbit_InclinationJ2000(KPCAAPlanetStrict planet, double JD)
 {
     switch (planet) {
-        case Mercury: {
+        case mercury: {
             return KPCAAElementsPlanetaryOrbit_MercuryInclinationJ2000(JD);
             break;
         }
-        case Venus: {
+        case venus: {
             return KPCAAElementsPlanetaryOrbit_VenusInclinationJ2000(JD);
             break;
         }
-        case Earth: {
+        case earth: {
             return KPCAAElementsPlanetaryOrbit_EarthInclinationJ2000(JD);
             break;
         }
-        case Mars: {
+        case mars: {
             return KPCAAElementsPlanetaryOrbit_MarsInclinationJ2000(JD);
             break;
         }
-        case Jupiter: {
+        case jupiter: {
             return KPCAAElementsPlanetaryOrbit_JupiterInclinationJ2000(JD);
             break;
         }
-        case Saturn: {
+        case saturn: {
             return KPCAAElementsPlanetaryOrbit_SaturnInclinationJ2000(JD);
             break;
         }
-        case Uranus: {
+        case uranus: {
             return KPCAAElementsPlanetaryOrbit_UranusInclinationJ2000(JD);
             break;
         }
-        case Neptune: {
+        case neptune: {
             return KPCAAElementsPlanetaryOrbit_NeptuneInclinationJ2000(JD);
             break;
         }
@@ -377,35 +377,35 @@ double KPCAAElementsPlanetaryOrbit_InclinationJ2000(KPCAAPlanetStrict planet, do
 double KPCAAElementsPlanetaryOrbit_LongitudeAscendingNode(KPCAAPlanetStrict planet, double JD)
 {
     switch (planet) {
-        case Mercury: {
+        case mercury: {
             return KPCAAElementsPlanetaryOrbit_MercuryLongitudeAscendingNode(JD);
             break;
         }
-        case Venus: {
+        case venus: {
             return KPCAAElementsPlanetaryOrbit_VenusLongitudeAscendingNode(JD);
             break;
         }
-        case Earth: {
+        case earth: {
             return -1.0;
             break;
         }
-        case Mars: {
+        case mars: {
             return KPCAAElementsPlanetaryOrbit_MarsLongitudeAscendingNode(JD);
             break;
         }
-        case Jupiter: {
+        case jupiter: {
             return KPCAAElementsPlanetaryOrbit_JupiterLongitudeAscendingNode(JD);
             break;
         }
-        case Saturn: {
+        case saturn: {
             return KPCAAElementsPlanetaryOrbit_SaturnLongitudeAscendingNode(JD);
             break;
         }
-        case Uranus: {
+        case uranus: {
             return KPCAAElementsPlanetaryOrbit_UranusLongitudeAscendingNode(JD);
             break;
         }
-        case Neptune: {
+        case neptune: {
             return KPCAAElementsPlanetaryOrbit_NeptuneLongitudeAscendingNode(JD);
             break;
         }
@@ -419,35 +419,35 @@ double KPCAAElementsPlanetaryOrbit_LongitudeAscendingNode(KPCAAPlanetStrict plan
 double KPCAAElementsPlanetaryOrbit_LongitudeAscendingNodeJ2000(KPCAAPlanetStrict planet, double JD)
 {
     switch (planet) {
-        case Mercury: {
+        case mercury: {
             return KPCAAElementsPlanetaryOrbit_MercuryLongitudeAscendingNodeJ2000(JD);
             break;
         }
-        case Venus: {
+        case venus: {
             return KPCAAElementsPlanetaryOrbit_VenusLongitudeAscendingNodeJ2000(JD);
             break;
         }
-        case Earth: {
+        case earth: {
             return KPCAAElementsPlanetaryOrbit_EarthLongitudeAscendingNodeJ2000(JD);
             break;
         }
-        case Mars: {
+        case mars: {
             return KPCAAElementsPlanetaryOrbit_MarsLongitudeAscendingNodeJ2000(JD);
             break;
         }
-        case Jupiter: {
+        case jupiter: {
             return KPCAAElementsPlanetaryOrbit_JupiterLongitudeAscendingNodeJ2000(JD);
             break;
         }
-        case Saturn: {
+        case saturn: {
             return KPCAAElementsPlanetaryOrbit_SaturnLongitudeAscendingNodeJ2000(JD);
             break;
         }
-        case Uranus: {
+        case uranus: {
             return KPCAAElementsPlanetaryOrbit_UranusLongitudeAscendingNodeJ2000(JD);
             break;
         }
-        case Neptune: {
+        case neptune: {
             return KPCAAElementsPlanetaryOrbit_NeptuneLongitudeAscendingNodeJ2000(JD);
             break;
         }
@@ -461,35 +461,35 @@ double KPCAAElementsPlanetaryOrbit_LongitudeAscendingNodeJ2000(KPCAAPlanetStrict
 double KPCAAElementsPlanetaryOrbit_LongitudePerihelion(KPCAAPlanetStrict planet, double JD)
 {
     switch (planet) {
-        case Mercury: {
+        case mercury: {
             return KPCAAElementsPlanetaryOrbit_MercuryLongitudePerihelion(JD);
             break;
         }
-        case Venus: {
+        case venus: {
             return KPCAAElementsPlanetaryOrbit_VenusLongitudePerihelion(JD);
             break;
         }
-        case Earth: {
+        case earth: {
             return KPCAAElementsPlanetaryOrbit_EarthLongitudePerihelion(JD);
             break;
         }
-        case Mars: {
+        case mars: {
             return KPCAAElementsPlanetaryOrbit_MarsLongitudePerihelion(JD);
             break;
         }
-        case Jupiter: {
+        case jupiter: {
             return KPCAAElementsPlanetaryOrbit_JupiterLongitudePerihelion(JD);
             break;
         }
-        case Saturn: {
+        case saturn: {
             return KPCAAElementsPlanetaryOrbit_SaturnLongitudePerihelion(JD);
             break;
         }
-        case Uranus: {
+        case uranus: {
             return KPCAAElementsPlanetaryOrbit_UranusLongitudePerihelion(JD);
             break;
         }
-        case Neptune: {
+        case neptune: {
             return KPCAAElementsPlanetaryOrbit_NeptuneLongitudePerihelion(JD);
             break;
         }
@@ -503,35 +503,35 @@ double KPCAAElementsPlanetaryOrbit_LongitudePerihelion(KPCAAPlanetStrict planet,
 double KPCAAElementsPlanetaryOrbit_LongitudePerihelionJ2000(KPCAAPlanetStrict planet, double JD)
 {
     switch (planet) {
-        case Mercury: {
+        case mercury: {
             return KPCAAElementsPlanetaryOrbit_MercuryLongitudePerihelionJ2000(JD);
             break;
         }
-        case Venus: {
+        case venus: {
             return KPCAAElementsPlanetaryOrbit_VenusLongitudePerihelionJ2000(JD);
             break;
         }
-        case Earth: {
+        case earth: {
             return KPCAAElementsPlanetaryOrbit_EarthLongitudePerihelionJ2000(JD);
             break;
         }
-        case Mars: {
+        case mars: {
             return KPCAAElementsPlanetaryOrbit_MarsLongitudePerihelionJ2000(JD);
             break;
         }
-        case Jupiter: {
+        case jupiter: {
             return KPCAAElementsPlanetaryOrbit_JupiterLongitudePerihelionJ2000(JD);
             break;
         }
-        case Saturn: {
+        case saturn: {
             return KPCAAElementsPlanetaryOrbit_SaturnLongitudePerihelionJ2000(JD);
             break;
         }
-        case Uranus: {
+        case uranus: {
             return KPCAAElementsPlanetaryOrbit_UranusLongitudePerihelionJ2000(JD);
             break;
         }
-        case Neptune: {
+        case neptune: {
             return KPCAAElementsPlanetaryOrbit_NeptuneLongitudePerihelionJ2000(JD);
             break;
         }

--- a/ObjCAA/KPCAAPlanetPerihelionAphelion.mm
+++ b/ObjCAA/KPCAAPlanetPerihelionAphelion.mm
@@ -140,28 +140,28 @@ double KPCAAPlanetPerihelionAphelion_NeptuneAphelion(long k)
 long KPCAAPlanetPerihelionAphelion_K(double Year, KPCAAPlanetStrict planet)
 {
     switch (planet) {
-        case Mercury:
+        case mercury:
             return KPCAAPlanetPerihelionAphelion_MercuryK(Year);
             break;
-        case Venus:
+        case venus:
             return KPCAAPlanetPerihelionAphelion_VenusK(Year);
             break;
-        case Earth:
+        case earth:
             return KPCAAPlanetPerihelionAphelion_EarthK(Year);
             break;
-        case Mars:
+        case mars:
             return KPCAAPlanetPerihelionAphelion_MarsK(Year);
             break;
-        case Jupiter:
+        case jupiter:
             return KPCAAPlanetPerihelionAphelion_JupiterK(Year);
             break;
-        case Saturn:
+        case saturn:
             return KPCAAPlanetPerihelionAphelion_SaturnK(Year);
             break;
-        case Uranus:
+        case uranus:
             return KPCAAPlanetPerihelionAphelion_UranusK(Year);
             break;
-        case Neptune:
+        case neptune:
             return KPCAAPlanetPerihelionAphelion_NeptuneK(Year);
             break;
         default:
@@ -173,28 +173,28 @@ long KPCAAPlanetPerihelionAphelion_K(double Year, KPCAAPlanetStrict planet)
 double KPCAAPlanetPerihelionAphelion_Perihelion(long k, KPCAAPlanetStrict planet)
 {
     switch (planet) {
-        case Mercury:
+        case mercury:
             return KPCAAPlanetPerihelionAphelion_MercuryPerihelion(k);
             break;
-        case Venus:
+        case venus:
             return KPCAAPlanetPerihelionAphelion_VenusPerihelion(k);
             break;
-        case Earth:
+        case earth:
             return KPCAAPlanetPerihelionAphelion_EarthPerihelion(k, YES);
             break;
-        case Mars:
+        case mars:
             return KPCAAPlanetPerihelionAphelion_MarsPerihelion(k);
             break;
-        case Jupiter:
+        case jupiter:
             return KPCAAPlanetPerihelionAphelion_JupiterPerihelion(k);
             break;
-        case Saturn:
+        case saturn:
             return KPCAAPlanetPerihelionAphelion_SaturnPerihelion(k);
             break;
-        case Uranus:
+        case uranus:
             return KPCAAPlanetPerihelionAphelion_UranusPerihelion(k);
             break;
-        case Neptune:
+        case neptune:
             return KPCAAPlanetPerihelionAphelion_NeptunePerihelion(k);
             break;
         default:
@@ -206,28 +206,28 @@ double KPCAAPlanetPerihelionAphelion_Perihelion(long k, KPCAAPlanetStrict planet
 double KPCAAPlanetPerihelionAphelion_Aphelion(long k, KPCAAPlanetStrict planet)
 {
     switch (planet) {
-        case Mercury:
+        case mercury:
             return KPCAAPlanetPerihelionAphelion_MercuryAphelion(k);
             break;
-        case Venus:
+        case venus:
             return KPCAAPlanetPerihelionAphelion_VenusAphelion(k);
             break;
-        case Earth:
+        case earth:
             return KPCAAPlanetPerihelionAphelion_EarthAphelion(k, YES);
             break;
-        case Mars:
+        case mars:
             return KPCAAPlanetPerihelionAphelion_MarsAphelion(k);
             break;
-        case Jupiter:
+        case jupiter:
             return KPCAAPlanetPerihelionAphelion_JupiterAphelion(k);
             break;
-        case Saturn:
+        case saturn:
             return KPCAAPlanetPerihelionAphelion_SaturnAphelion(k);
             break;
-        case Uranus:
+        case uranus:
             return KPCAAPlanetPerihelionAphelion_UranusAphelion(k);
             break;
-        case Neptune:
+        case neptune:
             return KPCAAPlanetPerihelionAphelion_NeptuneAphelion(k);
             break;
         default:

--- a/SwiftAA.xcodeproj/project.pbxproj
+++ b/SwiftAA.xcodeproj/project.pbxproj
@@ -2721,6 +2721,7 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = 9F29B4601B47313500B64C96;
 			productRefGroup = 9F29B46B1B47313500B64C96 /* Products */;

--- a/SwiftAA/CelestialBodies.swift
+++ b/SwiftAA/CelestialBodies.swift
@@ -85,7 +85,7 @@ public extension CelestialBody {
     ///
     /// - Parameter geographicCoordinates: The coordinates of the location on Earth.
     /// - Returns: A RiseTransitSetTimes object.
-    public func riseTransitSetTimes(for geographicCoordinates: GeographicCoordinates) -> RiseTransitSetTimes {
+    func riseTransitSetTimes(for geographicCoordinates: GeographicCoordinates) -> RiseTransitSetTimes {
         return RiseTransitSetTimes(celestialBody: self, geographicCoordinates: geographicCoordinates)
     }
     

--- a/SwiftAA/DateExtensions.swift
+++ b/SwiftAA/DateExtensions.swift
@@ -10,59 +10,59 @@ import Foundation
 
 public extension Date {
     /// The Julian Day of the date.
-    public var julianDay: JulianDay {
+    var julianDay: JulianDay {
         return JulianDay(self)
     }
     
     /// The year component of the date.
-    public var year: Int {
+    var year: Int {
         get { return Calendar.gregorianGMT.component(.year, from: self) }
     }
     
     /// The month component of the date
-    public var month: Int {
+    var month: Int {
         get { return Calendar.gregorianGMT.component(.month, from: self) }
     }
     
     /// The dat component of the date.
-    public var day: Int {
+    var day: Int {
         get { return Calendar.gregorianGMT.component(.day, from: self) }
     }
     
     /// The hour component of the date.
-    public var hour: Int {
+    var hour: Int {
         get { return Calendar.gregorianGMT.component(.hour, from: self) }
     }
     
     /// The fractional hour of the date
-    public var fractionalHour: Double {
+    var fractionalHour: Double {
         get { return Double(self.hour) + Double(self.minute)/60.0 + Double(self.second)/3600.0 + Double(self.nanosecond)/1e9/3600.0 }
     }
     
     /// The minute component of the date.
-    public var minute: Int {
+    var minute: Int {
         get { return Calendar.gregorianGMT.component(.minute, from: self) }
     }
     
     /// The second component of the date.
-    public var second: Int {
+    var second: Int {
         get { return Calendar.gregorianGMT.component(.second, from: self) }
     }
     
     /// The remainder of the date, in nanoseconds.
-    public var nanosecond: Int {
+    var nanosecond: Int {
         get { return Calendar.gregorianGMT.component(.nanosecond, from: self) }
     }
     
     /// Returns whether the date is in a leap year or not.
-    public var isLeap : Bool {
+    var isLeap : Bool {
         get { return ((self.year % 100) == 0) ? (self.year % 400) == 0 : (self.year % 4) == 0 }
     }
     
     /// Returns a new date corresponding the 1st of January of the same year.
     ///
     /// - Returns: A new date object.
-    public func januaryFirstDate() -> Date {
+    func januaryFirstDate() -> Date {
         var components = DateComponents()
         components.year = self.year
         components.month = 1
@@ -75,7 +75,7 @@ public extension Date {
     
     
     /// The fractional year corresponding of the date.
-    public var fractionalYear: Double {
+    var fractionalYear: Double {
         get {
             let daysCount = (self.isLeap) ? 366.0 : 365.0
             return Double(self.year) + ((self.julianDay.value - self.januaryFirstDate().julianDay.value) / daysCount)
@@ -85,7 +85,7 @@ public extension Date {
     /// Returns the number of integral days since January 1st, 2000.
     ///
     /// - Returns: The number of integral days since January 1st, 2000.
-    public func daysSince2000January1() -> Int {
+    func daysSince2000January1() -> Int {
         let A = 367*self.year
         let B = (7*(self.year + (self.month+9)/12))/4
         let C = (275*self.month)/9

--- a/SwiftAA/EllipticalPlanetaryDetails.swift
+++ b/SwiftAA/EllipticalPlanetaryDetails.swift
@@ -53,7 +53,7 @@ public extension EllipticalPlanetaryDetails {
     /// it is actually seen from the center of the moving Earth, and referred to the instantaneous equator, ecliptic
     /// and equinox.
     /// It accounts for 1) the effect of light-time and 2) the effect of the Earth motion. See AA p224.
-    public var apparentGeocentricEquatorialCoordinates: EquatorialCoordinates {
+    var apparentGeocentricEquatorialCoordinates: EquatorialCoordinates {
         get {
             let ra = Hour(self.planetaryDetails.ApparentGeocentricRA)
             let dec = Degree(self.planetaryDetails.ApparentGeocentricDeclination)

--- a/SwiftAA/JulianDay.swift
+++ b/SwiftAA/JulianDay.swift
@@ -59,7 +59,7 @@ public struct JulianDay: NumericType, CustomStringConvertible {
 
 public extension JulianDay {
     /// Returns a new Date object, in the Gregorian calendar, corresponding to the Julian Day value.
-    public var date: Date {
+    var date: Date {
         let aaDate = KPCAADate(julianDay: value, usingGregorianCalendar: true)!
         let decimalSeconds = aaDate.second()
         let roundedSeconds = decimalSeconds.rounded(.towardZero)
@@ -79,12 +79,12 @@ public extension JulianDay {
     /// Returns the so-called Modified Julian Day corresponding to the Julian Day value.
     /// Contrary to the JD, the Modified Julian Day begins at Greenwhich mean midnight.
     /// It is equal to JD - 2400 000.5
-    public var modified: Double {
+    var modified: Double {
         get { return self.value - ModifiedJulianDayZero }
     }
     
     /// Returns the Julian Day corresponding to the Greenwhich midnight before the actual value.
-    public var midnight: JulianDay { return JulianDay((value - 0.5).rounded(.down) + 0.5) }
+    var midnight: JulianDay { return JulianDay((value - 0.5).rounded(.down) + 0.5) }
     
     /// Returns the Julian Day corresponding to the geometric midnight local to a given Earth longitude,
     /// before the actual value. It is a direct function of the longitude, and makes no reference to time zone whatsoever.
@@ -94,7 +94,7 @@ public extension JulianDay {
     ///
     /// - Parameter longitude: The observer longitude
     /// - Returns:  Julian Day instance.
-    public func localMidnight(longitude: Degree) -> JulianDay {
+    func localMidnight(longitude: Degree) -> JulianDay {
         var shift = 0.0
         if longitude.inHours.value > self.date.fractionalHour { shift = -1.0 }
         else if longitude.inHours.value+12.0 < -self.date.fractionalHour { shift = +1.0 }
@@ -105,7 +105,7 @@ public extension JulianDay {
     ///
     /// - Parameter timeZone: The time zone.
     /// - Returns: A Julian Day object
-    public func localMidnight(timeZone: TimeZone) -> JulianDay {
+    func localMidnight(timeZone: TimeZone) -> JulianDay {
         let offsetFromGMT = JulianDay(Double(timeZone.secondsFromGMT(for: self.date)) / (60*60*24))
         return (self + offsetFromGMT).midnight - offsetFromGMT
     }
@@ -116,7 +116,7 @@ public extension JulianDay {
     /// of the date with the mean equator of the date).
     ///
     /// - Returns: The sidereal time in hours.
-    public func meanGreenwichSiderealTime() -> Hour {
+    func meanGreenwichSiderealTime() -> Hour {
         return Hour(KPCAASidereal_MeanGreenwichSiderealTime(self.value))
     }
     
@@ -126,7 +126,7 @@ public extension JulianDay {
     ///             Basically: this is the contrary of IAU decision. But this orientation is consistent
     ///             with longitude orientation in all other planets!
     /// - Returns: The sidereal time in hours.
-    public func meanLocalSiderealTime(longitude: Degree) -> Hour {
+    func meanLocalSiderealTime(longitude: Degree) -> Hour {
         return self.meanGreenwichSiderealTime() - longitude.inHours
     }
     
@@ -136,7 +136,7 @@ public extension JulianDay {
     /// that depends on the nutation in longitude, and the true obliquity of the ecliptic.
     ///
     /// - Returns: The sidereal time in hours.
-    public func apparentGreenwichSiderealTime() -> Hour {
+    func apparentGreenwichSiderealTime() -> Hour {
         return Hour(KPCAASidereal_ApparentGreenwichSiderealTime(self.value))
     }
     
@@ -146,7 +146,7 @@ public extension JulianDay {
     ///
     /// - Parameter mean: If true, compute the mean obliquity. Otherwise, compute the true obliquity.
     /// - Returns: The obliquity of the ecliptic, in degrees.
-    public func obliquityOfEcliptic(mean: Bool = true) -> Degree {
+    func obliquityOfEcliptic(mean: Bool = true) -> Degree {
         return Degree(KPCAANutation_ObliquityOfEcliptic(mean, self.value))
     }
     
@@ -156,7 +156,7 @@ public extension JulianDay {
     /// TD was later renamed TT for Terrestrial Time (which is a fairly unfortunate naming...).
     ///
     /// - Returns: The number of seconds (and fraction of thereof) between TD and UT.
-    public func deltaT() -> Second {
+    func deltaT() -> Second {
         return Second(KPCAADynamicalTime_DeltaT(self.value))
     }
     
@@ -164,7 +164,7 @@ public extension JulianDay {
     /// See here http://tycho.usno.navy.mil/leapsec.html for a thorough explanation.
     ///
     /// - Returns: The total number of leap seconds accumulated since their introduction until the given JD.
-    public func cumulativeLeapSeconds() -> Second {
+    func cumulativeLeapSeconds() -> Second {
         return Second(KPCAADynamicalTime_CumulativeLeapSeconds(self.value))
     }
     
@@ -174,7 +174,7 @@ public extension JulianDay {
     /// See AA p.77- and http://tycho.usno.navy.mil/systime.html
     ///
     /// - Returns: A new julian day
-    public func TTtoUTC() -> JulianDay {
+    func TTtoUTC() -> JulianDay {
         return JulianDay(KPCAADynamicalTime_TT2UTC(self.value))
     }
 
@@ -184,7 +184,7 @@ public extension JulianDay {
     /// See AA p.77- and http://tycho.usno.navy.mil/systime.html
     ///
     /// - Returns: A new julian day
-    public func UTCtoTT() -> JulianDay {
+    func UTCtoTT() -> JulianDay {
         return JulianDay(KPCAADynamicalTime_UTC2TT(self.value))
     }
 
@@ -193,7 +193,7 @@ public extension JulianDay {
     /// See AA p.77- and http://tycho.usno.navy.mil/systime.html
     ///
     /// - Returns: A new julian day
-    public func TTtoTAI() -> JulianDay {
+    func TTtoTAI() -> JulianDay {
         return JulianDay(KPCAADynamicalTime_TT2TAI(self.value))
     }
 
@@ -202,7 +202,7 @@ public extension JulianDay {
     /// See AA p.77- and http://tycho.usno.navy.mil/systime.html
     ///
     /// - Returns: A new julian day
-    public func TAItoTT() -> JulianDay {
+    func TAItoTT() -> JulianDay {
         return JulianDay(KPCAADynamicalTime_TAI2TT(self.value))
     }
 
@@ -215,7 +215,7 @@ public extension JulianDay {
     /// See AA p.77- and http://tycho.usno.navy.mil/systime.html
     ///
     /// - Returns: A new julian day
-    public func TTtoUT1() -> JulianDay {
+    func TTtoUT1() -> JulianDay {
         return JulianDay(KPCAADynamicalTime_TT2UT1(self.value))
     }
 
@@ -228,7 +228,7 @@ public extension JulianDay {
     /// See AA p.77- and http://tycho.usno.navy.mil/systime.html
     ///
     /// - Returns: A new julian day
-    public func UT1toTT() -> JulianDay {
+    func UT1toTT() -> JulianDay {
         return JulianDay(KPCAADynamicalTime_UT12TT(self.value))
     }
 
@@ -236,12 +236,12 @@ public extension JulianDay {
     /// See AA p.77- and http://tycho.usno.navy.mil/systime.html
     ///
     /// - Returns: A difference in Seconds.
-    public func UT1minusUTC() -> Second {
+    func UT1minusUTC() -> Second {
         return Second(KPCAADynamicalTime_UT1MinusUTC(self.value))
     }
     
     /// The description of the Julian Day.
-    public var description: String {
+    var description: String {
         switch self {
         case StandardEpoch_J2000_0: return "J2000.0"
         case StandardEpoch_B1950_0: return "B1950.0"

--- a/SwiftAA/Magnitudes.swift
+++ b/SwiftAA/Magnitudes.swift
@@ -13,7 +13,7 @@ public extension Magnitude {
     ///
     /// - Parameter m2: The secondary magnitude
     /// - Returns: The combined magnitude.
-    public func combine(with m2: Magnitude) -> Magnitude {
+    func combine(with m2: Magnitude) -> Magnitude {
         return Magnitude(KPCAAStellarMagnitudes_CombinedMagnitude(self.value, m2.value))
     }
     
@@ -21,7 +21,7 @@ public extension Magnitude {
     ///
     /// - Parameter m2: The other magnitude.
     /// - Returns: The brightness ratio.
-    public func brightnessRatio(with m2: Magnitude) -> Double {
+    func brightnessRatio(with m2: Magnitude) -> Double {
         return KPCAAStellarMagnitudes_BrightnessRatio(self.value, m2.value)
     }
 
@@ -31,7 +31,7 @@ public extension Magnitude {
     ///   - M: The absolute magnitude of the object.
     ///   - Av: The visual absorption factor.
     /// - Returns: The distance, in parsec.
-    public func distance(forAbsoluteMagnitude M: Magnitude, visualAbsorption Av: Magnitude = 0.0) -> Parsec {
+    func distance(forAbsoluteMagnitude M: Magnitude, visualAbsorption Av: Magnitude = 0.0) -> Parsec {
         return Parsec(pow(10.0, (self.value + 5.0 - M.value - Av.value)/5.0))
     }
     
@@ -39,7 +39,7 @@ public extension Magnitude {
     ///
     /// - Parameter r: The brightness ratio.
     /// - Returns: The magnitude difference.
-    static public func magnitudeDifference(forBrightnessRatio r: Double) -> Magnitude {
+    static func magnitudeDifference(forBrightnessRatio r: Double) -> Magnitude {
         return Magnitude(KPCAAStellarMagnitudes_MagnitudeDifference(r))
     }
 }

--- a/SwiftAA/NumericType.swift
+++ b/SwiftAA/NumericType.swift
@@ -55,7 +55,12 @@ extension _NumericType {
     public static func *= (lhs: inout Self, rhs: Self) { lhs = Self(lhs.value * rhs.value) }
     
     public var magnitude: Self { return Self(abs(value)) }
+
+    #if swift(>=4.2)
+    public func hash(into hasher: inout Hasher) { hasher.combine(value) }
+    #else
     public var hashValue: Int { return value.hashValue }
+    #endif
     
 }
 

--- a/SwiftAA/NumericType.swift
+++ b/SwiftAA/NumericType.swift
@@ -56,7 +56,8 @@ extension _NumericType {
     
     public var magnitude: Self { return Self(abs(value)) }
 
-    #if swift(>=4.2)
+    // This is compatible with Xcode 9 equivalent of `#if compiler(>=4.2)` (see https://github.com/apple/swift-evolution/blob/master/proposals/0212-compiler-version-directive.md)
+    #if swift(>=4.1.50) || (swift(>=3.4) && !swift(>=4.0))
     public func hash(into hasher: inout Hasher) { hasher.combine(value) }
     #else
     public var hashValue: Int { return value.hashValue }

--- a/SwiftAA/ScientificConstants.swift
+++ b/SwiftAA/ScientificConstants.swift
@@ -273,7 +273,7 @@ public extension KPCPlanetaryObject {
     }
     
     /// Returns the SwiftAA Class type for the given planetary object.
-    public var objectType: Planet.Type? {
+    var objectType: Planet.Type? {
         switch self {
         case .MERCURY:
             return SwiftAA.Mercury.self


### PR DESCRIPTION
This fixes Xcode 10.2 beta 2 compilation errors (they got stricter on C++ enums) and warnings. Tested both on Xcode 10.1 and Xcode 10.2b2. _Should_ work as well on Xcode 9 (but not tested).