### PR TITLE
Add initializer and convenience variable for coordinates at the center

### DIFF
--- a/Sources/SwiftAA/Moon.swift
+++ b/Sources/SwiftAA/Moon.swift
@@ -43,6 +43,21 @@ public struct SelenographicCoordinates {
     public var colongitude: Degree {
         get { return (450.0.degrees - self.longitude).reduced }
     }
+
+    /// A Selenographic coordinates centered at the equator and prime meridian.
+    public static var zero: SelenographicCoordinates {
+        return SelenographicCoordinates(longitude: 0.0.degrees, latitude: 0.0.degrees)
+    }
+
+    /// Returns a SelenographicCoordinates object.
+    ///
+    /// - Parameters:
+    ///   - longitude: The longitude.
+    ///   - latitude: The latitude
+    public init(longitude: Degree, latitude: Degree) {
+        self.longitude = longitude
+        self.latitude = latitude
+    }
 }
 
 


### PR DESCRIPTION
The public init is required to use some Moon functions that require a SelenographicCoordinates object. The default init is internal.