### PR TITLE
Remove library type for ObjCAA

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,6 @@ let package = Package(
         ),
         .library(
             name: "ObjCAA",
-            type: .dynamic,
             targets: ["ObjCAA"]
         ),
         .library(


### PR DESCRIPTION
Xcode will automatically select the proper library type if not specified. When linking with SwiftAA, both AA+ and ObjCAA will be statically linked regardless. But when using SwiftAA in a SwiftUI app, while in development all SwiftUI previews will fail because Xcode is unable to link ObjCAA properly.

This solves issue #88 at least temporarily until a proper way to build all dependencies as dynamic libraries is found. 