### PR TITLE
fundamental changes for building via SPM with AA+ 2.44

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.5
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -32,7 +32,13 @@ let package = Package(
             name: "AAplus",
             dependencies: [],
             path: "Sources/AA+",
-            exclude: ["naughter.css", "CMakeLists.txt", "AA+.htm"]
+            exclude: ["naughter.css",
+                      "CMakeLists.txt",
+                      "AA+.htm",
+                      "include/AAVSOP2013.h",
+                      "include/AA+.h",
+                      "AAVSOP2013.cpp",
+                      "AATest.cpp"]
         ),
         .target(
             name: "ObjCAA",
@@ -51,5 +57,5 @@ let package = Package(
             name: "SwiftAATests",
             dependencies: ["SwiftAA"]),
     ],
-    cxxLanguageStandard: .gnucxx14
+    cxxLanguageStandard: .gnucxx17
 )

--- a/Tests/ObjCAATests/EnumsTests.mm
+++ b/Tests/ObjCAATests/EnumsTests.mm
@@ -19,13 +19,13 @@
 
 - (void)testPlanetaryPhenomena
 {
-    XCTAssertEqual((NSUInteger)MERCURY, (NSUInteger)CAAPlanetaryPhenomena::PlanetaryObject::MERCURY);
-    XCTAssertEqual((NSUInteger)VENUS, (NSUInteger)CAAPlanetaryPhenomena::PlanetaryObject::VENUS);
-    XCTAssertEqual((NSUInteger)MARS, (NSUInteger)CAAPlanetaryPhenomena::PlanetaryObject::MARS);
-    XCTAssertEqual((NSUInteger)JUPITER, (NSUInteger)CAAPlanetaryPhenomena::PlanetaryObject::JUPITER);
-    XCTAssertEqual((NSUInteger)SATURN, (NSUInteger)CAAPlanetaryPhenomena::PlanetaryObject::SATURN);
-    XCTAssertEqual((NSUInteger)URANUS, (NSUInteger)CAAPlanetaryPhenomena::PlanetaryObject::URANUS);
-    XCTAssertEqual((NSUInteger)NEPTUNE, (NSUInteger)CAAPlanetaryPhenomena::PlanetaryObject::NEPTUNE);
+    XCTAssertEqual((NSUInteger)MERCURY, (NSUInteger)CAAPlanetaryPhenomena::Planet::MERCURY);
+    XCTAssertEqual((NSUInteger)VENUS, (NSUInteger)CAAPlanetaryPhenomena::Planet::VENUS);
+    XCTAssertEqual((NSUInteger)MARS, (NSUInteger)CAAPlanetaryPhenomena::Planet::MARS);
+    XCTAssertEqual((NSUInteger)JUPITER, (NSUInteger)CAAPlanetaryPhenomena::Planet::JUPITER);
+    XCTAssertEqual((NSUInteger)SATURN, (NSUInteger)CAAPlanetaryPhenomena::Planet::SATURN);
+    XCTAssertEqual((NSUInteger)URANUS, (NSUInteger)CAAPlanetaryPhenomena::Planet::URANUS);
+    XCTAssertEqual((NSUInteger)NEPTUNE, (NSUInteger)CAAPlanetaryPhenomena::Planet::NEPTUNE);
 }
 
 


### PR DESCRIPTION
This should fix #112

There are 2 ways to solve this problem. 

AA+ added VSOP2013 algorithm file (AAVSOP2013.h and AAVSOP2013.cpp), which makes use of C++ 17 filesystem APIs, which are only available on macOS 10.15 / iOS 13 and above. (Read about it here: https://stackoverflow.com/q/58667853)

One way is to raise deployment, but since SwiftAA doesn't (yet) use VSOP2013 file, another way is to exclude necessary files, which is the method used for this pull request.
