### PR TITLE
Podspec changes to hopefully solve issues

### DIFF
--- a/ObjCAA.podspec
+++ b/ObjCAA.podspec
@@ -32,6 +32,12 @@ is crafted.
   s.name          = "ObjCAA"
   s.source_files  = "Sources/ObjCAA", "Sources/ObjCAA/**/*.{h,cpp}", "Sources/aaplus-v2.44", "Sources/aaplus-v2.44/**/*.{h,cpp}"
   s.public_header_files = "Sources/ObjCAA/include/*.h"
-  s.exclude_files = "Sources/aaplus-v2.44/AATest.cpp"
+  s.exclude_files = "Sources/aaplus-v2.44/AATest.cpp", "Sources/aaplus-v2.44/include/AAVSOP2013.h", "Sources/aaplus-v2.44/AAVSOP2013.cpp"
+  
+  s.library = 'c++'
+  s.xcconfig = {
+       'CLANG_CXX_LANGUAGE_STANDARD' => 'c++17',
+       'CLANG_CXX_LIBRARY' => 'libc++'
+  }
 
 end


### PR DESCRIPTION
This should compile cpp17. At least it sort of works when I tried pod spec lint (for ObjCAA). Got an error for watchOS though. Couldn't lint SwiftAA properly as I can't point the dependency to my fork.