### PR TITLE
JulianDay.localMidnight(longitude: Degree) and RiseTransitSet(...) were returning wrong results for years before year 1583 and epoch 0 due to internal conversion from JulianDay to Gregorian Date object

### DIFF
--- a/Sources/SwiftAA/JulianDay.swift
+++ b/Sources/SwiftAA/JulianDay.swift
@@ -101,7 +101,7 @@ public extension JulianDay {
         var shift = 0.0
         if longitude.inHours.value > self.date.fractionalHour { shift = -1.0 }
         else if longitude.inHours.value+12.0 < -self.date.fractionalHour { shift = +1.0 }
-        return self.midnight.date.addingTimeInterval(longitude.inHours.inSeconds.value).julianDay + JulianDay(shift)
+        return JulianDay(self.midnight.value + longitude.value / 15.0 / 24.0) + JulianDay(shift)
     }
     
     /// Returns the Julian Day corresponding to the local midnight, based on timezone.

--- a/Sources/SwiftAA/RiseTransitSet.swift
+++ b/Sources/SwiftAA/RiseTransitSet.swift
@@ -65,7 +65,7 @@ public func riseTransitSet(forJulianDay julianDay: JulianDay,
 {
     // Do NOT pass Right Ascension values in degrees, as requested by AA+. It will be transformed later.
     // See CAARiseTransitSet::CalculateTransit, line 72.
-    let details = KPCAARiseTransitSet_Calculate(julianDay.UTCtoTT().value,
+    let details = KPCAARiseTransitSet_Calculate(julianDay.value,
                                                 equCoords1.alpha.value,
                                                 equCoords1.delta.value,
                                                 equCoords2.alpha.value,
@@ -76,35 +76,9 @@ public func riseTransitSet(forJulianDay julianDay: JulianDay,
                                                 geoCoords.latitude.value,
                                                 apparentRiseSetAltitude.value)
     
-    let date = julianDay.date
-    let sexagesimalRise = Hour(details.Rise).sexagesimal
-    let sexagesimalTransit = Hour(details.Transit).sexagesimal
-    let sexagesimalSet = Hour(details.Set).sexagesimal
-    
-    let rise = JulianDay(year: date.year,
-                         month: date.month,
-                         day: date.day,
-                         hour: sexagesimalRise.radical,
-                         minute: sexagesimalRise.minute,
-                         second: sexagesimalRise.second)
-    
-    let transit = JulianDay(year: date.year,
-                            month: date.month,
-                            day: date.day,
-                            hour: sexagesimalTransit.radical,
-                            minute: sexagesimalTransit.minute,
-                            second: sexagesimalTransit.second)
-    
-    let set = JulianDay(year: date.year,
-                        month: date.month,
-                        day: date.day,
-                        hour: sexagesimalSet.radical,
-                        minute: sexagesimalSet.minute,
-                        second: sexagesimalSet.second)
-    
-    //    let rise = julianDay + Hour(details.Rise).inJulianDays
-    //    let transit = julianDay + Hour(details.Transit).inJulianDays
-    //    let set = julianDay + Hour(details.Set).inJulianDays
+    let rise = julianDay + Hour(details.Rise).inJulianDays
+    let transit = julianDay + Hour(details.Transit).inJulianDays
+    let set = julianDay + Hour(details.Set).inJulianDays
     
     return RiseTransitSetTimesDetails(isRiseValid: details.isRiseValid,
                                       riseTime: rise,

--- a/Sources/SwiftAA/RiseTransitSet.swift
+++ b/Sources/SwiftAA/RiseTransitSet.swift
@@ -65,7 +65,7 @@ public func riseTransitSet(forJulianDay julianDay: JulianDay,
 {
     // Do NOT pass Right Ascension values in degrees, as requested by AA+. It will be transformed later.
     // See CAARiseTransitSet::CalculateTransit, line 72.
-    let details = KPCAARiseTransitSet_Calculate(julianDay.value,
+    let details = KPCAARiseTransitSet_Calculate(julianDay.UTCtoTT().value,
                                                 equCoords1.alpha.value,
                                                 equCoords1.delta.value,
                                                 equCoords2.alpha.value,


### PR DESCRIPTION
I fixed the following two function which returned wrong results due to internal conversion from JulianDay to a Gregorian Date object. I couldn't see any comment explaining why the conversion to a Gregorian Date object was made and don't see a logical reason myself, so replaced it by pure JulianDay calculation which apparently works.

JulianDay.localMidnight(longitude: Degree) fixed for JD before epoch 0

RiseTransitSet(...) fixed for stars before the JD equivalent of Gregorian year 1583

Does anyone know why internall a conversion to Date was used here? Is my change acceptable?

In general, I assume SwiftAA is supported years before Gregorian year 1583 and also before Epoch 0. I noticed potential other limitations that far into the past in other functions and will write PR for those later.

[I recreated this PR correctly from a dedicated branch now as the previous identical one was from master]