### PR TITLE
wrong transit result for Sun with RisetSetTransit due to internal conversion with UTCtoTT()

### DIFF
--- a/Sources/SwiftAA/RiseTransitSet.swift
+++ b/Sources/SwiftAA/RiseTransitSet.swift
@@ -65,7 +65,7 @@ public func riseTransitSet(forJulianDay julianDay: JulianDay,
 {
     // Do NOT pass Right Ascension values in degrees, as requested by AA+. It will be transformed later.
     // See CAARiseTransitSet::CalculateTransit, line 72.
-    let details = KPCAARiseTransitSet_Calculate(julianDay.UTCtoTT().value,
+    let details = KPCAARiseTransitSet_Calculate(julianDay.value,
                                                 equCoords1.alpha.value,
                                                 equCoords1.delta.value,
                                                 equCoords2.alpha.value,


### PR DESCRIPTION
RisetSetTransit for the Sun resulted in a transit horizontal coordinate slightly off from the expected meridian location when verifying back with equatorialCoordinates.makeHorizontalCoordinates(...).
I think it's due to the UTCtoTT() applied inside  RisetSetTransit(...).
This PR removed the UTCtoTT() from RiseSetTransit.

Demonstrator:

```
import SwiftAA
	func test() {
		let sun = Sun(julianDay: JulianDay(2461040.5)) // 2025-12-31 00:00:00
		let loc = GeographicCoordinates(positivelyWestwardLongitude: Degree(0), latitude: Degree(51.1789), altitude: Meter(0))
		let sunTimes = RiseTransitSetTimes(celestialBody: sun, geographicCoordinates: loc, riseSetAltitude: 0)
		if let solarNoon = sunTimes.transitTime {
			let sunNoon = Sun(julianDay: solarNoon)
			let sunNoonAz = sunNoon.equatorialCoordinates.makeHorizontalCoordinates(for: loc, at: solarNoon).northBasedAzimuth
			print("calculated Sun horizontal azimuth \(sunNoonAz) at sun transit on \(solarNoon.date)")
		}
	}
```

```
before fix:
calculated Sun horizontal azimuth +179°43'24.947" at sun transit on 2025-12-31 12:01:57 +0000

after fix:
calculated Sun horizontal azimuth +179°59'58.401"° at sun transit on 2025-12-31 12:03:06 +0000
```

The azimuth in both results matches the UTC time for each when comparing with other astronomical software.