### PR TITLE
Fixes #131: added isTransitValid into RiseSetTransit result

### DIFF
--- a/Sources/AABridge/KPCAARiseTransitSet.cpp
+++ b/Sources/AABridge/KPCAARiseTransitSet.cpp
@@ -25,6 +25,7 @@ KPCAARiseTransitSetDetails KPCAARiseTransitSet_Calculate(double JD,
     KPCAARiseTransitSetDetails details;
     details.isRiseValid = detailsPlus.bRiseValid;
     details.Rise = detailsPlus.Rise;
+    details.isTransitValid = detailsPlus.bTransitValid;
     details.isTransitAboveHorizon = detailsPlus.bTransitAboveHorizon;
     details.Transit = detailsPlus.Transit;
     details.isSetValid = detailsPlus.bSetValid;

--- a/Sources/AABridge/include/KPCAARiseTransitSet.h
+++ b/Sources/AABridge/include/KPCAARiseTransitSet.h
@@ -15,6 +15,7 @@ extern "C" {
 typedef struct KPCAARiseTransitSetDetails {
     bool isRiseValid;
     double Rise;
+    bool isTransitValid;
     bool isTransitAboveHorizon;
     double Transit;
     bool isSetValid;

--- a/Sources/SwiftAA/RiseTransitSet.swift
+++ b/Sources/SwiftAA/RiseTransitSet.swift
@@ -13,6 +13,7 @@ import AABridge
 public struct RiseTransitSetTimesDetails {
     public private(set) var isRiseValid: Bool
     public private(set) var riseTime: JulianDay
+    public private(set) var isTransitValid: Bool
     public private(set) var isTransitAboveHorizon: Bool
     public private(set) var transitTime: JulianDay
     public private(set) var isSetValid: Bool
@@ -108,6 +109,7 @@ public func riseTransitSet(forJulianDay julianDay: JulianDay,
     
     return RiseTransitSetTimesDetails(isRiseValid: details.isRiseValid,
                                       riseTime: rise,
+                                      isTransitValid: details.isTransitValid,
                                       isTransitAboveHorizon: details.isTransitAboveHorizon,
                                       transitTime: transit,
                                       isSetValid: details.isSetValid,
@@ -186,7 +188,7 @@ public struct RiseTransitSetTimes {
     
     /// The transit time of the celestial body, in Julian Day.
     public var transitTime: JulianDay? {
-        get { return (self.details != nil && self.details!.isTransitAboveHorizon) ? self.details!.transitTime : nil }
+        get { return (self.details != nil && self.details!.isTransitValid) ? self.details!.transitTime : nil }
     }
     
     /// The set time of the celestial body, in Julian Day.


### PR DESCRIPTION
Added previously missing isTransitValid into the result from RiseSetTransit and replaced isTransitAboveHorizon with isTransitValid when deciding about returning a non-nil transit times object.