### PR TITLE
Fixed results for solstice, equinox and lengthOfSeason calculation for Earth before Gregorian year 1BC (epoch 0) 

### DIFF
--- a/Sources/SwiftAA/Earth.swift
+++ b/Sources/SwiftAA/Earth.swift
@@ -74,7 +74,7 @@ public class Earth: Object, PlanetaryBase, PlanetaryOrbits {
      - returns: A julian day of the TT time of the equinox.
      */
     public func equinox(of equinoxType: EarthEquinoxType) -> JulianDay {
-        let year = self.julianDay.date.year
+        let year = self.julianDay.year
         switch equinoxType {
         case .northwardSpring:
             return JulianDay(KPCAAEquinoxesAndSolstices_NorthwardEquinox(year, self.highPrecision))
@@ -92,7 +92,7 @@ public class Earth: Object, PlanetaryBase, PlanetaryOrbits {
      - returns: A julian day of the TT time of the solstice.
      */
     public func solstice(of solsticeType: EarthSolsticeType) -> JulianDay {
-        let year = self.julianDay.date.year
+        let year = self.julianDay.year
         switch solsticeType {
         case .northernSummer:
             return JulianDay(KPCAAEquinoxesAndSolstices_NorthernSolstice(year, self.highPrecision))
@@ -110,7 +110,7 @@ public class Earth: Object, PlanetaryBase, PlanetaryOrbits {
      - returns: A length in (Julian) Days.
      */
     public func lengthOfSeason(_ season: Season, northernHemisphere: Bool) -> Day {
-        let year = self.julianDay.date.year
+        let year = self.julianDay.year
         switch season {
         case .spring:
             return Day(KPCAAEquinoxesAndSolstices_LengthOfSpring(year, northernHemisphere, self.highPrecision))

--- a/Sources/SwiftAA/JulianDay.swift
+++ b/Sources/SwiftAA/JulianDay.swift
@@ -89,8 +89,7 @@ public extension JulianDay {
     /// and they expect a year 0 and not the 0-skip of the Gregorian calendar.
     /// This intermediate use of the Gregorian calendar in general instead of Julian Day is risky and most likely slow, but changing would require a lot of work.
     var year: Int {
-        let calendar = Calendar.current
-        let dateComponents = calendar.dateComponents([.era, .year], from: date)
+        let dateComponents = Calendar.gregorianGMT.dateComponents([.era, .year], from: date)
         if let era = dateComponents.era {
             return era > 0 ? dateComponents.year! : (1 - dateComponents.year!)
 		} else {

--- a/Sources/SwiftAA/JulianDay.swift
+++ b/Sources/SwiftAA/JulianDay.swift
@@ -91,7 +91,9 @@ public extension JulianDay {
     /// This intermediate use of the Gregorian calendar in general instead of Julian Day is risky and most likely slow, but changing would require a lot of work.
     var year: Int {
         let aaDate = KPCAADate_CreateWithJulianDay(value, true)
-        return KPCAADate_GetYear(aaDate)
+        let aaYear = KPCAADate_GetYear(aaDate)
+        KPCAADate_Destroy(aaDate)
+        return aaYear
     }
 
     /// Returns the so-called Modified Julian Day corresponding to the Julian Day value.

--- a/Sources/SwiftAA/JulianDay.swift
+++ b/Sources/SwiftAA/JulianDay.swift
@@ -85,16 +85,13 @@ public extension JulianDay {
     /// Returns the astronomical year count of this Julian Day value. The year before 1 is returned as 0, the year before 0 returned as -1.
     /// This astronomical  counting differs from the Gregorian year where the year before year 1 is 1BC.
     /// The reason to offer this separate attribute is the difficulty of extracting the year before 1 from a Swift Date object
+    /// and before the year equivalent to JulianDay 0, Swift Date always returns era 0 year 4712
     /// and many SwiftAA functions use an intermediate conversion from a JulianDay to a Gregorian year, and will fail when used on a Swift Date object for years before 1
     /// and they expect a year 0 and not the 0-skip of the Gregorian calendar.
     /// This intermediate use of the Gregorian calendar in general instead of Julian Day is risky and most likely slow, but changing would require a lot of work.
     var year: Int {
-        let dateComponents = Calendar.gregorianGMT.dateComponents([.era, .year], from: date)
-        if let era = dateComponents.era {
-            return era > 0 ? dateComponents.year! : (1 - dateComponents.year!)
-		} else {
-            return dateComponents.year!
-        }
+        let aaDate = KPCAADate_CreateWithJulianDay(value, true)
+        return KPCAADate_GetYear(aaDate)
     }
 
     /// Returns the so-called Modified Julian Day corresponding to the Julian Day value.


### PR DESCRIPTION
In SwiftAA.Earth a few functions converted internally from Julian Day to a Gregorian Swift Date object which caused wrong results for negative years before epoch 0 (Gregorian year 1BC) as they wrapped around to positive epoch years (Gregorian AD years). The real bug could be considered in the Swift Date object as it is difficult to extract years before 1AD correctly.

This for example resulted in the solstice of 1AD instead of 1BC:
```
let year_1BC_Jan_1_JD = JulianDay(1720694.5)
let earth = Earth(julianDay: year_1BC_Jan_1)
let solsticeJD = earth.solstice(of: EarthSolsticeType.northernSummer)
```

Caused by the problematic Swift Date object when used like it was for solstice calculation for example like this:
```
   public func solstice(of solsticeType: EarthSolsticeType) -> JulianDay {
        let year = self.julianDay.date.year
        switch solsticeType {
        case .northernSummer:
            return JulianDay(KPCAAEquinoxesAndSolstices_NorthernSolstice(year, self.highPrecision))
        case .southernSummer:
            return JulianDay(KPCAAEquinoxesAndSolstices_SouthernSolstice(year, self.highPrecision))
        }
    }
```

As fix I added an attribute year to JulianDay which returns the astronomical year count like aaplus internally expects it, i.e. negative years with year 0. All this conversation to Gregorian Date objects isn't really safe, but at least with this fix it should work for a few thousand years before 1AD.