### PR TITLE
Make GalileanMoonRectangularCoordinates X/Y/Z publicly readable

### DIFF
--- a/Sources/SwiftAA/JupiterMoons.swift
+++ b/Sources/SwiftAA/JupiterMoons.swift
@@ -9,7 +9,7 @@
 import Foundation
 import ObjCAA
 
-typealias JupiterEquatorialRadius = Double
+public typealias JupiterEquatorialRadius = Double
 
 
 /// These coordinates describe the position of the four great satellites of Jupiter, with respect to the planet,
@@ -19,9 +19,9 @@ typealias JupiterEquatorialRadius = Double
 /// Y is measured positively to the north, the axis coinciding with the rotation axis of the planet.
 /// Z is negative if the satellite is closer to the Earth than Jupiter, and positive otherwise.
 public struct GalileanMoonRectangularCoordinates {
-    fileprivate(set) var X: JupiterEquatorialRadius
-    fileprivate(set) var Y: JupiterEquatorialRadius
-    fileprivate(set) var Z: Double
+    public fileprivate(set) var X: JupiterEquatorialRadius
+    public fileprivate(set) var Y: JupiterEquatorialRadius
+    public fileprivate(set) var Z: Double
     
     init(components: KPCAA3DCoordinateComponents) {
         self.X = components.X


### PR DESCRIPTION
GalileanMoon.rectangularCoordinates(_:) is public and returns a public GalileanMoonRectangularCoordinates, but its X/Y/Z stored properties have internal getters (fileprivate(set) var with no explicit getter access), so callers outside SwiftAA get 'X' is inaccessible due to 'internal' protection level. This makes the Galilean-moon apparent positions effectively unusable from client code.

This widens the getters to public (setters stay fileprivate) and makes the JupiterEquatorialRadius typealias public so the public properties can expose it. No behavioural change. Mirrors how other coordinate types in the library expose their components.